### PR TITLE
Thaumcraft & PneumaticCraft integration

### DIFF
--- a/src/api/java/pneumaticCraft/api/IHeatExchangerLogic.java
+++ b/src/api/java/pneumaticCraft/api/IHeatExchangerLogic.java
@@ -1,0 +1,77 @@
+package pneumaticCraft.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * DO NOT IMPLEMENT THIS CLASS YOURSELF! Use PneumaticRegistry.getInstance().getHeatExchangerLogic() !
+ * @author MineMaarten
+ * www.minemaarten.com
+ */
+public interface IHeatExchangerLogic{
+
+    /**
+     * Call this to tick this logic, and make the heat disperse itself.
+     */
+    public void update();
+
+    /**
+     * When called (preferably on tile entity load and neighbor block/tile entity change) this will add all IHeatExchanger neighbor TileEntities as connected heat exchangers.
+     * It will also take care of blocks like Lava.
+     * 
+     * You don't _have_ to call this method, if this heat exchanger is not connected to the outside world (for example the heat of the liquid
+     * plastic in the Plastic Mixer).
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     * @param validSides Can be left out as vararg, meaning every side can be connected. When one or more sides are specified this will constrain
+     * this heat exchanger to only connect to other heat exchangers on these sides.
+     */
+    public void initializeAsHull(World world, int x, int y, int z, ForgeDirection... validSides);
+
+    /**
+     * When called, this will connect these two heat exchangers. You should only call this on one of the two heat exchangers. 
+     * @param exchanger
+     */
+    public void addConnectedExchanger(IHeatExchangerLogic exchanger);
+
+    public void removeConnectedExchanger(IHeatExchangerLogic exchanger);
+
+    /**
+     * A heat exchanger starts with 295 degrees Kelvin (20 degrees Celcius) by default.
+     * @param temperature in degrees Kelvin
+     */
+    public void setTemperature(double temperature);
+
+    public double getTemperature();
+
+    /**
+     * The higher the thermal resistance, the slower the heat disperses.
+     * @param thermalResistance By default it's 1.
+     */
+    public void setThermalResistance(double thermalResistance);
+
+    public double getThermalResistance();
+
+    /**
+     * The higher the capacity, the more heat can be 'stored'. This means that an object with a high capacity can heat up an object with a lower
+     * capacity without losing any significant amount of temperature.
+     * @param capacity
+     */
+    public void setThermalCapacity(double capacity);
+
+    public double getThermalCapacity();
+
+    public void writeToNBT(NBTTagCompound tag);
+
+    public void readFromNBT(NBTTagCompound tag);
+
+    /**
+     * Adds heat (= deltaT * Thermal Capacity) to this exchanger. negative values will remove heat.
+     * @param amount
+     */
+    public void addHeat(double amount);
+
+}

--- a/src/api/java/pneumaticCraft/api/PneumaticRegistry.java
+++ b/src/api/java/pneumaticCraft/api/PneumaticRegistry.java
@@ -1,0 +1,198 @@
+package pneumaticCraft.api;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import pneumaticCraft.api.client.pneumaticHelmet.IBlockTrackEntry;
+import pneumaticCraft.api.client.pneumaticHelmet.IEntityTrackEntry;
+import pneumaticCraft.api.client.pneumaticHelmet.IHackableBlock;
+import pneumaticCraft.api.client.pneumaticHelmet.IHackableEntity;
+import pneumaticCraft.api.drone.ICustomBlockInteract;
+import pneumaticCraft.api.drone.IPathfindHandler;
+import pneumaticCraft.api.item.IInventoryItem;
+import pneumaticCraft.api.recipe.IPneumaticRecipeRegistry;
+import pneumaticCraft.api.tileentity.HeatBehaviour;
+
+/**
+ * This class can be used to register and access various things to and from the mod.
+ */
+public class PneumaticRegistry{
+    /**
+     * This field, which is initialized in PneumaticCraft's preInit, will give you access to various registration and access options.
+     * @deprecated This field isn't going to be removed, but it'll be marked private. use getInstance().
+     */
+    @Deprecated
+    public static IPneumaticCraftInterface instance;
+
+    public static IPneumaticCraftInterface getInstance(){
+        return instance;
+    }
+
+    public static void init(IPneumaticCraftInterface inter){
+        if(instance == null) instance = inter;//only allow initialization once; by PneumaticCraft
+    }
+
+    public static interface IPneumaticCraftInterface{
+
+        public IPneumaticRecipeRegistry getRecipeRegistry();
+
+        /*
+         * ------------- Pneumatic Helmet --------------
+         */
+
+        public void registerEntityTrackEntry(Class<? extends IEntityTrackEntry> entry);
+
+        public void registerBlockTrackEntry(IBlockTrackEntry entry);
+
+        public void addHackable(Class<? extends Entity> entityClazz, Class<? extends IHackableEntity> iHackable);
+
+        public void addHackable(Block block, Class<? extends IHackableBlock> iHackable);
+
+        /**
+         * Returns a list of all current successful hacks of a given entity. This is used for example in Enderman hacking, so the user
+         * can only hack an enderman once (more times wouldn't have any effect). This is mostly used for display purposes.
+         * @param entity
+         * @return empty list if no hacks.
+         */
+        public List<IHackableEntity> getCurrentEntityHacks(Entity entity);
+
+        /*
+         * ------------- Drones --------------
+         */
+
+        /**
+         * Normally drones will pathfind through any block that doesn't have any collisions (Block#getBlocksMovement returns true).
+         * With this method you can register custom blocks to allow the drone to pathfind through them. If the block requires any special
+         * handling, like allow pathfinding on certain conditions, you can pass a IPathFindHandler with the registry.
+         * @param block
+         * @param handler can be null, to always allow pathfinding through this block.
+         */
+        public void addPathfindableBlock(Block block, IPathfindHandler handler);
+
+        /**
+         * This will add a puzzle piece that has only a Area white- and blacklist parameter (similar to a GoTo piece).
+         * It will do the specified behaviour. This can be used to create energy import/export widgets.
+         * @param interactor
+         */
+        public void registerCustomBlockInteractor(ICustomBlockInteract interactor);
+
+        /**
+         * Will spawn in a Drone a distance away from the given coordinate. When there is an inventory at the given x,y,z the drone will export the items in there. If there isn't or items don't fit, the drone will travel to 5 blocks above the specified
+         * y level, and drop the deliveredStacks. When there isn't a clear path for the items to fall these 5 blocks the Drone will deliver at a
+         * y level above the specified y that _is_ clear. If no clear blocks can be found (when there are only solid blocks), the Drone will
+         * drop the items very high up in the air instead, and drop them there.
+         * 
+         * When the Drone is tried to be caught by a player (by wrenching it), the drone will only the drop the items that it was delivering (or
+         * none if it dropped those items already). The Drone itself never will be dropped.
+         * 
+         * @param x
+         * @param y
+         * @param z
+         * @param deliveredStacks stacks that are delivered by the drone. When no stacks, or more than 65 stacks are given, this will generate an IllegalArgumentException.
+         * @return the drone. You can use this to set a custom name for example (defaults to "Amadron Delivery Drone").
+         */
+        public EntityCreature deliverItemsAmazonStyle(World world, int x, int y, int z, ItemStack... deliveredStacks);
+
+        /**
+         * The opposite of deliverItemsAmazonStyle. Will retrieve the queried items from an inventory at the specified location.
+         * @param world
+         * @param x
+         * @param y
+         * @param z
+         * @param queriedStacks
+         * @return
+         */
+        public EntityCreature retrieveItemsAmazonStyle(World world, int x, int y, int z, ItemStack... queriedStacks);
+
+        /**
+         * Similar to deliverItemsAmazonStyle, but with Fluids. Will spawn in a Drone that will fill an IFluidHandler at the given x,y,z. If the fluid doesn't fit or there isn't a IFluidHandler, the fluid is lost.
+         * @param world
+         * @param x
+         * @param y
+         * @param z
+         * @param deliveredFluid
+         * @return
+         */
+        public EntityCreature deliverFluidAmazonStyle(World world, int x, int y, int z, FluidStack deliveredFluid);
+
+        /**
+         * The opposite of deliverFluidAmazonStyle. Will retrieve the queried fluid from an IFluidHandler at the specified location.
+         * @param world
+         * @param x
+         * @param y
+         * @param z
+         * @param queriedStacks
+         * @return
+         */
+        public EntityCreature retrieveFluidAmazonStyle(World world, int x, int y, int z, FluidStack queriedFluid);
+
+        /*
+         * --------------- Items -------------------
+         */
+        /**
+         * See {@link pneumaticCraft.api.item.IInventoryItem}
+         * @param handler
+         */
+        public void registerInventoryItem(IInventoryItem handler);
+
+        /*
+         * ----------------- Heat System --------------
+         */
+        public IHeatExchangerLogic getHeatExchangerLogic();
+
+        public void registerBlockExchanger(Block block, double temperature, double thermalResistance);
+
+        public void registerHeatBehaviour(Class<? extends HeatBehaviour> heatBehaviour);
+
+        /*
+         * ---------------- Power Generation -----------
+         */
+
+        /**
+         * Adds a burnable liquid to the Liquid Compressor's available burnable fuels.
+         * @param fluid
+         * @param mLPerBucket the amount of mL generated for 1000mB of the fuel. As comparison, one piece of coal generates 16000mL in an Air Compressor.
+         */
+        public void registerFuel(Fluid fluid, int mLPerBucket);
+
+        /*
+         * --------------- Misc -------------------
+         */
+
+        /**
+         * Returns the amount of Security Stations that disallow interaction with the given coordinate for the given player.
+         * Usually you'd disallow interaction when this returns > 0.
+         * @param world
+         * @param x
+         * @param y
+         * @param z
+         * @param player
+         * @param showRangeLines When true, any Security Station that prevents interaction will show the line grid (server --> client update is handled internally).
+         * @return The amount of Security Stations that disallow interaction for the given player.
+         * This method throws an IllegalArgumentException when tried to be called from the client side!
+         */
+        public int getProtectingSecurityStations(World world, int x, int y, int z, EntityPlayer player, boolean showRangeLines);
+
+        /**
+         * Use this to register ISimpleBlockRenderHandler render id's of full blocks, those of which should be able to be used for the Pneumatic Door Base camouflage.
+         * @param id
+         */
+        public void registerConcealableRenderId(int id);
+
+        /**
+         * Used to register a liquid that represents liquid XP (like MFR mob essence, OpenBlocks liquid XP).
+         * This is used in the Aerial Interface to pump XP in/out of the player.
+         * @param fluid
+         * @param liquidToPointRatio The amount of liquid (in mB) used to get one XP point. In OpenBlocks this is 20 (mB/point).
+         */
+        public void registerXPLiquid(Fluid fluid, int liquidToPointRatio);
+
+    }
+}

--- a/src/api/java/pneumaticCraft/api/actuator/IActuator.java
+++ b/src/api/java/pneumaticCraft/api/actuator/IActuator.java
@@ -1,0 +1,32 @@
+package pneumaticCraft.api.actuator;
+
+import java.util.List;
+
+import net.minecraft.tileentity.TileEntity;
+
+public interface IActuator{
+    /**
+     * Same as {@link pneumaticCraft.api.universalSensor.ISensorSetting#getSensorPath()}
+     * @return
+     */
+    public String getSensorPath();
+
+    /**
+     * When returned true, the GUI will enable the textbox writing, otherwise not.
+     * @return
+     */
+    public boolean needsTextBox();
+
+    /**
+     * Should return the description of this sensor displayed in the GUI stat. Information should at least include
+     * when this sensor emits redstone and how (analog (1 through 15), or digital).
+     * @return
+     */
+    public List<String> getDescription();
+
+    /**
+     * 
+     * @param universalActuator
+     */
+    public void actuate(TileEntity universalActuator);
+}

--- a/src/api/java/pneumaticCraft/api/block/BlockSupplier.java
+++ b/src/api/java/pneumaticCraft/api/block/BlockSupplier.java
@@ -1,0 +1,77 @@
+package pneumaticCraft.api.block;
+
+import net.minecraft.block.Block;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class BlockSupplier{
+    // private static Class blockClass;
+
+    /**
+     * @param blockName
+     * @return
+     */
+    public static Block getBlock(String blockName){
+        return GameRegistry.findBlock("PneumaticCraft", blockName);
+        /*try {
+            if(blockClass == null) blockClass = Class.forName("pneumaticCraft.common.block.Blockss");
+            return (Block)blockClass.getField(blockName).get(null);
+        } catch(Exception e) {
+            System.err.println("[PneumaticCraft API] Block supply failed for block: " + blockName);
+            return null;
+        }*/
+    }
+
+    /*
+     The following is a list of all the block names that can be passed as argument in getBlock(String) to get a PneumaticCraft block.
+     
+     
+     pressureTube               meta = tube type
+     airCompressor
+     airCannon
+     pressureChamberWall        meta < 6 ? wall : window
+     pressureChamberValve
+     pressureChamberInterface
+     squidPlant
+     fireFlower
+     creeperPlant
+     slimePlant
+     rainPlant
+     enderPlant
+     lightningPlant
+     adrenalinePlant
+     burstPlant
+     potionPlant
+     repulsionPlant
+     heliumPlant
+     flyingFlower
+     musicPlant
+     propulsionPlant
+     chopperPlant
+     chargingStation
+     elevatorBase
+     elevatorFrame
+     vacuumPump
+     pneumaticDoorBase
+     pneumaticDoor
+     assemblyPlatform
+     assemblyIOUnit
+     assemblyDrill
+     assemblyLaser
+     assemblyController
+     advancedPressureTube       meta = tube type (like 'pressureTube')
+     compressedIron
+     uvLightBox
+     etchingAcid
+     securityStation
+     universalSensor
+     pneumaticGenerator
+     electricCompressor
+     pneumaticEngine
+     kineticCompressor
+     aerialInterface
+     electrostaticCompressor
+     aphorismTile
+     omnidirectionalHopper
+
+     */
+}

--- a/src/api/java/pneumaticCraft/api/block/IPneumaticWrenchable.java
+++ b/src/api/java/pneumaticCraft/api/block/IPneumaticWrenchable.java
@@ -1,0 +1,14 @@
+package pneumaticCraft.api.block;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Should be implemented by any block or FMP that allows to be rotated by a Pneumatic Wrench. It uses almost the same
+ * rotate method as the Vanilla (Forge) method. However it uses energy to rotate (when rotateBlock() return true).
+ */
+public interface IPneumaticWrenchable{
+
+    public boolean rotateBlock(World world, EntityPlayer player, int x, int y, int z, ForgeDirection side);
+}

--- a/src/api/java/pneumaticCraft/api/client/GuiAnimatedStatSupplier.java
+++ b/src/api/java/pneumaticCraft/api/client/GuiAnimatedStatSupplier.java
@@ -1,0 +1,49 @@
+package pneumaticCraft.api.client;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.item.ItemStack;
+
+/**
+ * With this class you can retrieve new instances of the PneumaticCraft's IGuiAnimatedStat implementation. You can use these in Gui's as 
+ * well as anywhere you like. When you use these in Gui's you need to pass a valid GuiScreen instance, if you don't you can just pass
+ * null.
+ */
+public class GuiAnimatedStatSupplier{
+    private static Class animatedStatClass;
+
+    public static IGuiAnimatedStat getAnimatedStat(GuiScreen gui, int backgroundColor){
+        return getAnimatedStat(new Class[]{GuiScreen.class, int.class}, gui, backgroundColor);
+    }
+
+    /**
+     * Returns a GuiAnimatedStat which uses an itemstack as static icon.
+     * @param gui
+     * @param iconStack
+     * @param backgroundColor
+     * @return
+     */
+    public static IGuiAnimatedStat getAnimatedStat(GuiScreen gui, ItemStack iconStack, int backgroundColor){
+        return getAnimatedStat(new Class[]{GuiScreen.class, int.class, ItemStack.class}, gui, backgroundColor, iconStack);
+    }
+
+    /**
+     * Returns a GuiAnimatedStat which uses a texture location as static icon.
+     * @param gui
+     * @param iconTexture / text
+     * @param backgroundColor
+     * @return
+     */
+    public static IGuiAnimatedStat getAnimatedStat(GuiScreen gui, String iconTexture, int backgroundColor){
+        return getAnimatedStat(new Class[]{GuiScreen.class, int.class, String.class}, gui, backgroundColor, iconTexture);
+    }
+
+    private static IGuiAnimatedStat getAnimatedStat(Class[] constructorClasses, Object... constructorParameters){
+        try {
+            if(animatedStatClass == null) animatedStatClass = Class.forName("pneumaticCraft.client.gui.widget.GuiAnimatedStat");
+            return (IGuiAnimatedStat)animatedStatClass.getConstructor(constructorClasses).newInstance(constructorParameters);
+        } catch(Exception e) {
+            System.err.println("Failed to retrieve an GuiAnimatedStat instance from PneumaticCraft.");
+        }
+        return null;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/client/GuiElementRenderer.java
+++ b/src/api/java/pneumaticCraft/api/client/GuiElementRenderer.java
@@ -1,0 +1,32 @@
+package pneumaticCraft.api.client;
+
+import java.lang.reflect.Method;
+
+import net.minecraft.client.gui.FontRenderer;
+
+public class GuiElementRenderer{
+    private static Method drawGaugeMethod;
+
+    /**
+     * Draws a Pressure Gauge, the same which is also used in many PneumaticCraft applications.
+     * @param fontRenderer          fontrenderer used to draw the numbers of the pressure gauge.
+     * @param minPressure           The minimal pressure that needs to be displayed (this is -1 in most applications).
+     * @param maxPressure           The maximal pressure that needs to be rendererd (this is 7 for tier one machines, and 25 for tier two).
+     * @param dangerPressure        The transition pressure from green to red (this is 5 for tier one, and 29 for tier two machines).
+     * @param minWorkingPressure    The transition pressure from yellow to green (variates per machine).
+     * @param currentPressure       The pressure that the needle should point to.
+     * @param xPos                  x position of the gauge.
+     * @param yPos                  y position of the gauge.
+     * @param zLevel                z position of the gauge (Gui#zLevel, -90, for in normal GUI's).
+     */
+    public static void drawPressureGauge(FontRenderer fontRenderer, float minPressure, float maxPressure, float dangerPressure, float minWorkingPressure, float currentPressure, int xPos, int yPos, float zLevel){
+        try {
+            if(drawGaugeMethod == null) {
+                drawGaugeMethod = Class.forName("pneumaticCraft.client.gui.GuiUtils").getMethod("drawPressureGauge", FontRenderer.class, float.class, float.class, float.class, float.class, float.class, int.class, int.class, float.class);
+            }
+            drawGaugeMethod.invoke(null, fontRenderer, minPressure, maxPressure, dangerPressure, minWorkingPressure, currentPressure, xPos, yPos, zLevel);
+        } catch(Exception e) {
+            System.err.println("Failed to render a Pressure Gauge from PneumaticCraft.");
+        }
+    }
+}

--- a/src/api/java/pneumaticCraft/api/client/IGuiAnimatedStat.java
+++ b/src/api/java/pneumaticCraft/api/client/IGuiAnimatedStat.java
@@ -1,0 +1,179 @@
+package pneumaticCraft.api.client;
+
+import java.awt.Rectangle;
+import java.util.List;
+
+/**
+ * This interface doesn't have to be implemented. In PneumaticCraft there already is one class which implements this interface
+ * which is used many times in PneumaticCraft (GUI stats, Pneumatic Helmet 2D and 3D stats). You can get an instance of this
+ * class as well. Information about this you can find in GuiAnimatedStatSupplier.java. Implementing your own version of
+ * animated stats can be implemented as well via this interface, and they will interact with the PneumaticCraft GuiAnimatedStats
+ * if you implement it correctly.
+ */
+
+public interface IGuiAnimatedStat{
+
+    /**
+     * When you call this method with a set of coordinates representing the button location and dimensions, you'll get
+     * these parameters back scaled to the GuiAnimatedStat's scale.
+     * @param origX Button start X.
+     * @param origY Button start Y.
+     * @param width Button width.
+     * @param height Button height.
+     * @return rectangle containing the new location and dimensions.
+     */
+    public Rectangle getButtonScaledRectangle(int origX, int origY, int width, int height);
+
+    /**
+     * When passed 0.5F for example, the text of the stat will be half as big (so more text can fit into a certain area).
+     * @param scale
+     */
+    public void scaleTextSize(float scale);
+
+    /**
+     * Returns true if the statistic expands to the left.
+     * @return
+     */
+    public boolean isLeftSided();
+
+    /**
+     * Returns true if the statistic is done with expanding (when text will be displayed).
+     * @return
+     */
+    public boolean isDoneExpanding();
+
+    /**
+     * Pass true if the statistic should expand to the left, otherwise false.
+     * @param leftSided
+     */
+    public void setLeftSided(boolean leftSided);
+
+    /**
+     * Sets the main text of this stat. Every line should be stored in a seperate list element. Upon rendering,
+     * EnumChatFormattings will be respected. When you call this method, Too long lines will be divided into multiple shorter ones
+     * to fit in the GUI.
+     * @param text
+     * @return this, so you can chain calls.
+     */
+    public IGuiAnimatedStat setText(List<String> text);
+
+    /**
+     * Sets the line to a single line. Upon rendering,
+     * EnumChatFormattings will be respected. When you call this method, Too long lines will be divided into multiple shorter ones
+     * to fit in the GUI.
+     * @param text
+     * @return this, so you can chain calls.
+     */
+    public IGuiAnimatedStat setText(String text);
+
+    /**
+     * Sets the main text of this stat. Every line should be stored in a seperate list element. Upon rendering,
+     * EnumChatFormattings will be respected. This version of the text setting doesn't handle too long lines.
+     * @param text
+     */
+    public void setTextWithoutCuttingString(List<String> text);
+
+    /**
+     * Sets the title of this stat. It will automatically get the yellow color assigned.
+     * @param title
+     */
+    public void setTitle(String title);
+
+    /**
+     * Returns the title of this stat (obviously without color prefix).
+     * @return
+     */
+    public String getTitle();
+
+    /**
+     * Defines what dimensions the stat should have when it is not expanded (default 17x17) and resets the stat to these dimensions.
+     * Used in PneumaticCraft by the block/entity tracker stats, they are 0x0 when not expanded so it looks like they expand
+     * (and appear) from nothing.
+     * @param minWidth
+     * @param minHeight
+     */
+    public void setMinDimensionsAndReset(int minWidth, int minHeight);
+
+    /**
+     * When this stat gets a parent stat assigned, the y of this stat will be the same as the parent's plus this stat's
+     * baseY. This will cause this stat to move up and down when the parent's stat expands/moves.
+     * @param stat
+     */
+    public void setParentStat(IGuiAnimatedStat stat);
+
+    /**
+     * Sets the x location of this stat.
+     * @param x
+     */
+    public void setBaseX(int x);
+
+    /**
+     * Sets the base Y of this stat.
+     * @param y
+     */
+    public void setBaseY(int y);
+
+    /**
+     * Returns the real Y of this stat. This is the same as getBaseY when there is no parent stat, but if there is this method
+     * returns the value described in setParentStat(IGuiAnimatedStat stat).
+     * @return
+     */
+    public int getAffectedY();
+
+    public int getBaseX();
+
+    public int getBaseY();
+
+    /**
+     * Returns the Y size of this stat.
+     * @return
+     */
+    public int getHeight();
+
+    /**
+     * Returns the X size of this stat.
+     * @return
+     */
+    public int getWidth();
+
+    public Rectangle getBounds();
+
+    /**
+     * This method should be called every game tick to update the logic of the stat (expanding of the stat).
+     */
+    public void update();
+
+    /**
+     * Should be called every render tick when and where you want to render the stat.
+     * @param mouseX
+     * @param mouseY
+     * @param partialTicks
+     */
+    public void render(int mouseX, int mouseY, float partialTicks);
+
+    /**
+     * This method will handle mouse clicks. This will handle open/closing of the stat when the mouse clicks it.
+     * @param x
+     * @param y
+     * @param button
+     * @return
+     */
+    public void onMouseClicked(int x, int y, int button);
+
+    /**
+     * Forces the stat to close.
+     */
+    public void closeWindow();
+
+    /**
+     * Forces the stat to expand.
+     */
+    public void openWindow();
+
+    /**
+     * Returns true if the stat is expanding.
+     * @return
+     */
+    public boolean isClicked();
+
+}

--- a/src/api/java/pneumaticCraft/api/client/assemblymachine/AssemblyRenderOverriding.java
+++ b/src/api/java/pneumaticCraft/api/client/assemblymachine/AssemblyRenderOverriding.java
@@ -1,0 +1,55 @@
+package pneumaticCraft.api.client.assemblymachine;
+
+import java.util.HashMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class AssemblyRenderOverriding{
+    public static final HashMap<Integer, IAssemblyRenderOverriding> renderOverrides = new HashMap<Integer, IAssemblyRenderOverriding>();
+
+    public static void addRenderOverride(Block block, IAssemblyRenderOverriding renderOverride){
+        renderOverrides.put(Block.getIdFromBlock(block), renderOverride);
+    }
+
+    public static void addRenderOverride(Item item, IAssemblyRenderOverriding renderOverride){
+        renderOverrides.put(Item.getIdFromItem(item), renderOverride);
+    }
+
+    public static interface IAssemblyRenderOverriding{
+        /**
+         * This method will be called just before the IO Unit's held stack is being rendered. You can insert GL11 calls here to
+         * rotate the model for example. push and pop matrices are not needed, this is done for you.
+         *  You can also choose to do the whole rendering yourself, you'll need to return false then to indicate that
+         *  PneumaticCraft shouldn't render the item.
+         *  @param renderedStack itemStack that is being rendered
+         *  @return true if PneumaticCraft should render the item (after your changes), or false to cancel rendering.
+         */
+        public boolean applyRenderChangeIOUnit(ItemStack renderedStack);
+
+        /**
+         * Same deal as with the applyRenderChangeIOUnit(), but now for the Assembly Platform.
+         * @param renderedStack itemStack that is being rendered
+         * @return true if PneumaticCraft should render the item (after your changes), or false to cancel rendering.
+         */
+        public boolean applyRenderChangePlatform(ItemStack renderedStack);
+
+        /**
+         * Should return the distance the claw travels before it is gripped to the stack.
+         * By default it's 0.0875F for items and 0.00625F for blocks, 0.09375 when the claw is completely closed.
+         * @param renderedStack
+         * @return
+         */
+        public float getIOUnitClawShift(ItemStack renderedStack);
+
+        /**
+         * Should return the distance the claw travels before it is gripped to the stack.
+         * By default it's 0.0875F for items and 0.00625F for blocks, 0.09375 when the claw is completely closed.
+         * @param renderedStack
+         * @return
+         */
+        public float getPlatformClawShift(ItemStack renderedStack);
+
+    }
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/BlockTrackEvent.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/BlockTrackEvent.java
@@ -1,0 +1,28 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a helmet Block Tracker is about to track a block. Can be canceled to prevent tracking.
+ * Posted on MinecraftForge.EVENT_BUS
+ * @author MineMaarten
+ */
+@Cancelable
+public class BlockTrackEvent extends Event{
+
+    public final World world;
+    public final int x, y, z;
+    public final TileEntity te;
+
+    public BlockTrackEvent(World world, int x, int y, int z, TileEntity te){
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.te = te;
+    }
+
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/EntityTrackEvent.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/EntityTrackEvent.java
@@ -1,0 +1,20 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import net.minecraft.entity.Entity;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a helmet Block Tracker is about to track an entity. Can be canceled to prevent tracking.
+ * Posted on MinecraftForge.EVENT_BUS
+ * @author MineMaarten
+ */
+@Cancelable
+public class EntityTrackEvent extends Event{
+    public final Entity trackingEntity;
+
+    public EntityTrackEvent(Entity trackingEntity){
+        this.trackingEntity = trackingEntity;
+    }
+
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IBlockTrackEntry.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IBlockTrackEntry.java
@@ -1,0 +1,80 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+public interface IBlockTrackEntry{
+    /**
+     * This method should return true if the coordinate checked is one that
+     * should be tracked. Most entries will just return true when the blockID is
+     * the one that they track.
+     * 
+     * @param world
+     *            The world that is examined.
+     * @param x
+     *            The x coordinate of the block examined.
+     * @param y
+     *            The y coordinate of the block examined.
+     * @param z
+     *            The z coordinate of the block examined.
+     * @param block
+     *            The block of the current coordinate. This will save you a
+     *            call to World.getBlock().
+     * @param te  The TileEntity at this x,y,z.
+     * @return true if the coordinate should be tracked by this BlockTrackEntry.
+     */
+    public boolean shouldTrackWithThisEntry(IBlockAccess world, int x, int y, int z, Block block, TileEntity te);
+
+    /**
+     * This method defines if the block should be updated by the server (each 5
+     * seconds). This is specifically aimed at Tile Entities, as the server will
+     * send an NBT packet. This method returns true at for instance Chests and
+     * Mob Spawners, to get the inventory at the client side and the time to the
+     * next spawn respectively.
+     * @param te The TileEntity at the currently checked location.
+     * 
+     * @return true if the Tile Entity should be updated, or false when it
+     *         doesn't have to.
+     */
+    public boolean shouldBeUpdatedFromServer(TileEntity te);
+
+    /**
+     * The return of this method defines at how many tracked blocks of this type
+     * the HUD should stop displaying text at the tracked blocks of this type.
+     * 
+     * @return amount of blocks the HUD should stop displaying the block info.
+     */
+    public int spamThreshold();
+
+    /**
+     * This method is called each render tick to retrieve the blocks additional
+     * information. The method behaves the same as the addInformation method in
+     * the Item class. This method only will be called if
+     * shouldTrackWithThisEntry() returned true and the player hovers over the
+     * coordinate.
+     * 
+     * @param world
+     *            The world the block is in.
+     * @param x
+     *            The x coordinate the block is at.
+     * @param y
+     *            The y coordinate the block is at.
+     * @param z
+     *            The z coordinate the block is at.
+     * @param te  The TileEntity at the x,y,z.
+     * @param infoList
+     *            The list of lines to display.
+     */
+    public void addInformation(World world, int x, int y, int z, TileEntity te, List<String> infoList);
+
+    /**
+     * This method is called when displaying the currently tracked blocks.
+     * Will be tried to be mapped to the localization file first.
+     * @return the name of the group of this entry.
+     */
+    public String getEntryName();
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IEntityTrackEntry.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IEntityTrackEntry.java
@@ -1,0 +1,49 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+
+/**
+ * Implement this class and register it by adding it to the entityTrackEntries class.
+ * There needs to be a parameterless constructor. For every entity that's applicable for this definition, an instance is created.
+ */
+public interface IEntityTrackEntry{
+    /**
+     * Return true if you want to add a tooltip for the given entity.
+     * @param entity
+     * @return
+     */
+    public boolean isApplicable(Entity entity);
+
+    /**
+     * Add info to the tab. This is only called when isApplicable returned true.
+     * @param entity
+     * @param curInfo
+     */
+    public void addInfo(Entity entity, List<String> curInfo);
+
+    /**
+     * Update is called every (client) tick, and can be used to update something like a timer (used for the Creeper countdown).
+     * @param entity
+     */
+    public void update(Entity entity);
+
+    /**
+     * Called every render tick, this method can be used to render additional info. Used for Drone AI visualisation.
+     * @param entity
+     * @param partialTicks TODO
+     */
+    public void render(Entity entity, float partialTicks);
+
+    /**
+     * Just a basic implementation class that can be used if an update and render method isn't needed.
+     */
+    public static abstract class EntityTrackEntry implements IEntityTrackEntry{
+        @Override
+        public void update(Entity entity){}
+
+        @Override
+        public void render(Entity entity, float partialTicks){}
+    }
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IGuiScreen.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IGuiScreen.java
@@ -1,0 +1,15 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+import net.minecraft.client.gui.FontRenderer;
+
+/**
+ * Just an interface to give access to GuiSreen#buttonList and GuiScreen#fontRenderer. An instance of this class can
+ * safely be casted to GuiSreen if needed.
+ */
+public interface IGuiScreen{
+    public List getButtonList();
+
+    public FontRenderer getFontRenderer();
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IHackableBlock.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IHackableBlock.java
@@ -1,0 +1,69 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+/**
+Use this interface to specify any hackable block. When it's your block, you can simply implement this interface in the 
+block's class. If you don't have access to the class (vanilla blocks), you can implement this interface in a separate class
+and register it using PneumaticRegistry.registry.addHackable(blockClass, IHackableBlockClass). With the former way there will be one instance only per type. In the latter, there will
+be an IHackableBlock instance for every block.
+*/
+public interface IHackableBlock{
+    /**
+     * Should return a unique id to represent this hackable. Used in NBT saving to be able to trigger the afterHackTime after a server restart.
+     * Null is a valid return: afterHackTick will not be triggered at all in that case.
+     * 
+     * CURRENTLY THIS ISN'T IMPLEMENTED.
+     * @return
+     */
+    public String getId();
+
+    /**
+        Returning true will allow the player to hack this block. This can be used to only allow hacking on certain conditions.
+    */
+    public boolean canHack(IBlockAccess world, int x, int y, int z, EntityPlayer player);
+
+    /**
+        Add info that is displayed on the tracker tooltip here. Text like "Hack to explode" can be added.
+        This method is only called when canHack(World, int, int, int) returned true.
+        The added lines automatically will be tried to get localized.
+    */
+    public void addInfo(World world, int x, int y, int z, List<String> curInfo, EntityPlayer player);
+
+    /**
+     * Add info that is being displayed after hacking, as long as 'afterHackTick' is returning true.
+     * Things like "Neutralized".
+     * The added lines automatically will be tried to get localized.
+     * @param entity
+     * @param curInfo
+     * @param player
+     */
+    public void addPostHackInfo(World world, int x, int y, int z, List<String> curInfo, EntityPlayer player);
+
+    /**
+        Return the time it takes to hack this block in ticks. For more powerful hacks, a longer required hacking time is adviced.
+    */
+    public int getHackTime(IBlockAccess world, int x, int y, int z, EntityPlayer player);
+
+    /**
+        When the player hacked the block for getHackTime(World, int, int, int) ticks this will be called on both server and client side.
+    */
+    public void onHackFinished(World world, int x, int y, int z, EntityPlayer player);
+
+    /**
+     * Called every tick after the hacking finished (on both server and client side). Returning true will keep this going (for mob spawners, to keep them neutralized),
+     * or false to stop ticking (for door/lever hacking).
+     * 
+     * CURRENTLY THIS METHOD WILL STOP GETTING INVOKED AFTER A SERVER RESTART!
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     * @return
+     */
+    public boolean afterHackTick(World world, int x, int y, int z);
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IHackableEntity.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IHackableEntity.java
@@ -1,0 +1,59 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+
+/**
+Use this interface to specify any hackable entity. When it's your entity, you can simply implement this interface in the 
+entity's class. If you don't have access to the class (vanilla entities), you can implement this interface in a separate class
+and register it using PneumaticRegistry.registry.addHackable(entityClass, IHackableEntityClass). In both ways there will be an IHackableEntity instance for every entity.
+*/
+public interface IHackableEntity{
+
+    /**
+     * Should return a unique id to represent this hackable. Used in NBT saving to be able to trigger the afterHackTime after a server restart.
+     * Null is a valid return: afterHackTick will not be triggered at all in that case.
+     * @return
+     */
+    public String getId();
+
+    /**
+    Returning true will allow the player to hack this entity. This can be used to only allow hacking on certain conditions.
+    */
+    public boolean canHack(Entity entity, EntityPlayer player);
+
+    /**
+        Add info that is displayed on the tracker tooltip here. Text like "Hack to explode" can be added.
+        This method is only called when canHack(Entity) returned true.
+        The added lines automatically will be tried to get localized.
+    */
+    public void addInfo(Entity entity, List<String> curInfo, EntityPlayer player);
+
+    /**
+     * Add info that is being displayed after hacking, as long as 'afterHackTick' is returning true.
+     * Things like "Neutralized".
+     * The added lines automatically will be tried to get localized.
+     * @param entity
+     * @param curInfo
+     * @param player
+     */
+    public void addPostHackInfo(Entity entity, List<String> curInfo, EntityPlayer player);
+
+    /**
+        Return the time it takes to hack this entity in ticks. For more powerful hacks, a longer required hacking time is adviced.
+    */
+    public int getHackTime(Entity entity, EntityPlayer player);
+
+    /**
+        When the player hacked the entity for getHackTime(Entity) ticks this will be called on both client and server side.
+    */
+    public void onHackFinished(Entity entity, EntityPlayer player);
+
+    /**
+     * Called every tick after the hacking finished. Returning true will keep this going (for mob spawners, to keep them neutralized),
+     * or false to stop ticking (for door/lever hacking).
+     */
+    public boolean afterHackTick(Entity entity);
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IOptionPage.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IOptionPage.java
@@ -1,0 +1,46 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+
+/**
+ * The Option Page is the page you see when you press 'F' (by default) with a Pneumatic Helmet equipped. You can register this class
+ * by returning a new instance of this class at {@link IUpgradeRenderHandler#getGuiOptionsPage()}
+ */
+public interface IOptionPage{
+
+    /**
+     * This string is used in the text of the button of this page.
+     * @return
+     */
+    public String getPageName();
+
+    /**
+     * Here you can initialize your buttons and stuff like with a GuiScreen. For buttons, don't use button id 100 and up, as they
+     * will be used as selection buttons for other option pages in the main GuiScreen.
+     * @param gui
+     */
+    public void initGui(IGuiScreen gui);
+
+    /**
+     * Same as GuiScreen#actionPerformed(GuiButton).
+     * @param button
+     */
+    public void actionPerformed(GuiButton button);
+
+    /**
+     * Same as {@link GuiScreen#drawScreen(int, int, float)}
+     * Here you can render additional things like text.
+     * @param x
+     * @param y
+     * @param partialTicks
+     */
+    public void drawScreen(int x, int y, float partialTicks);
+
+    /**
+     * Same as GuiScreen#keyTyped(char, int).
+     * @param ch
+     * @param key
+     */
+    public void keyTyped(char ch, int key);
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IUpgradeRenderHandler.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/IUpgradeRenderHandler.java
@@ -1,0 +1,92 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.config.Configuration;
+import pneumaticCraft.api.client.IGuiAnimatedStat;
+
+/**
+ * To add upgrades for in the Pneumatic Helmet implement this interface. You can add members to this class, however these can only 
+ * be client sided members as this class will be used as singleton. Therefore, only one of these instances exist at the server side
+ * so any member that is used server side will affect every player.
+ *
+ */
+public interface IUpgradeRenderHandler{
+
+    /**
+     * Return here the name of the upgrade. This is displayed in the formatting [upgradeName] + " " + "found"/"not found"  on
+     * initialization of the helmet.
+     * @return
+     */
+    public String getUpgradeName();
+
+    /**
+     * Being called from PneumaticCraft's config handler, you can use this method to read settings like stat positions
+     * @param config PneumaticCraft's config file.
+     */
+    public void initConfig(Configuration config);
+
+    /**
+     * When called this should save the settings to the config file. Called when changed a setting. When you want to use
+     * PneumaticCraft's config file, save a reference of it somewhere in this class when the config gets passed in the
+     * initConfig() method (this always will be called first).
+     */
+    public void saveToConfig();
+
+    /**
+     * This method will be called every client tick, and should be used to update logic like the tracking and velocities of stuff.
+     * @param player
+     * @param rangeUpgrades amount of range upgrades installed in the helmet.
+     */
+    public void update(EntityPlayer player, int rangeUpgrades);
+
+    /**
+     * Called in the 3D render stage (renderWorldLastEvent)
+     * @param partialTicks
+     */
+    public void render3D(float partialTicks);
+
+    /**
+     * Called in the 2D render stage (Render Tick Handler)
+     * @param partialTicks
+     * @param helmetEnabled is true when isEnabled() returned true earlier. Can be used to close AnimatedStats for instance.
+     * However this is already handled if you return an AnimatedStat in getAnimatedStat().
+     */
+    public void render2D(float partialTicks, boolean helmetEnabled);
+
+    /**
+     * You can return a GuiAnimatedStat here, that the HUDHandler will pick up and render. It also automatically opens and closes
+     * the stat when needed. The GuiMoveStat uses this method to retrieve the to be moved stat.
+     * @return null if no stat used.
+     */
+    public IGuiAnimatedStat getAnimatedStat();
+
+    /**
+     * Should return true if this upgrade handler is enabled for the given stacks placed in the helmet.
+     * @param upgradeStacks
+     * @return
+     */
+    public boolean isEnabled(ItemStack[] upgradeStacks);
+
+    /**
+     * Returns the usage in mL/tick when this upgrade handler is enabled.
+     * @param rangeUpgrades amount of range upgrades installed in the helmet.
+     * @param player
+     * @return usage in mL/tick
+     */
+    public float getEnergyUsage(int rangeUpgrades, EntityPlayer player);
+
+    /**
+     * Called when (re-)equipped the helmet this method should be used to clear information like current tracked entities.
+     * So clearing lists and other references as this handler should re-acquire when reinstalled.
+     */
+    public void reset();
+
+    /**
+     * When you have some options for your upgrade handler you could return a new instance of an IOptionsPage.
+     * When you do so, it will automatically get picked up by the options handler, and it will be added to the 
+     * options GUI when this upgrade returns true when calling isEnabled(). Returning null is valid.
+     * @return
+     */
+    public IOptionPage getGuiOptionsPage();
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/InventoryTrackEvent.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/InventoryTrackEvent.java
@@ -1,0 +1,28 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a helmet Block Tracker is about to track an inventory. Can be canceled to prevent tracking.
+ * Posted on MinecraftForge.EVENT_BUS
+ * @author MineMaarten
+ */
+@Cancelable
+public class InventoryTrackEvent extends Event{
+    private final TileEntity inventory;
+
+    public InventoryTrackEvent(TileEntity inventory){
+        this.inventory = inventory;
+    }
+
+    public TileEntity getTileEntity(){
+        return inventory;
+    }
+
+    public IInventory getInventory(){
+        return (IInventory)inventory;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/RenderHandlerRegistry.java
+++ b/src/api/java/pneumaticCraft/api/client/pneumaticHelmet/RenderHandlerRegistry.java
@@ -1,0 +1,10 @@
+package pneumaticCraft.api.client.pneumaticHelmet;
+
+import java.util.List;
+
+public class RenderHandlerRegistry{
+    /**
+     * With this field you can register your render handlers. This field is initialized in the PreInit phase of PneumaticCraft's loading phase.
+     */
+    public static List<IUpgradeRenderHandler> renderHandlers;
+}

--- a/src/api/java/pneumaticCraft/api/drone/AmadronRetrievalEvent.java
+++ b/src/api/java/pneumaticCraft/api/drone/AmadronRetrievalEvent.java
@@ -1,0 +1,16 @@
+package pneumaticCraft.api.drone;
+
+import pneumaticCraft.api.PneumaticRegistry;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired (on the MinecraftForge.EVENT_BUS) when {@link PneumaticRegistry.IPneumaticCraftInterface#retrieveItemsAmazonStyle(net.minecraft.world.World, int, int, int, net.minecraft.item.ItemStack...) has successfully retrieved the items requested.
+ * The same drone will be passed as the one returned in the retrieve method.
+ */
+public class AmadronRetrievalEvent extends Event{
+    public final IDrone drone;
+
+    public AmadronRetrievalEvent(IDrone drone){
+        this.drone = drone;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/drone/DroneConstructingEvent.java
+++ b/src/api/java/pneumaticCraft/api/drone/DroneConstructingEvent.java
@@ -1,0 +1,11 @@
+package pneumaticCraft.api.drone;
+
+import cpw.mods.fml.common.eventhandler.Event;
+
+public class DroneConstructingEvent extends Event{
+    public final IDrone drone;
+
+    public DroneConstructingEvent(IDrone drone){
+        this.drone = drone;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/drone/DroneSuicideEvent.java
+++ b/src/api/java/pneumaticCraft/api/drone/DroneSuicideEvent.java
@@ -1,0 +1,14 @@
+package pneumaticCraft.api.drone;
+
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Event called on the MinecraftForge.EVENT_BUS just before a Drone executes a Suicide piece. Used internally by PneumaticCraft to handle Amadron requests.
+ */
+public class DroneSuicideEvent extends Event{
+    public final IDrone drone;
+
+    public DroneSuicideEvent(IDrone drone){
+        this.drone = drone;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/drone/IBlockInteractHandler.java
+++ b/src/api/java/pneumaticCraft/api/drone/IBlockInteractHandler.java
@@ -1,0 +1,26 @@
+package pneumaticCraft.api.drone;
+
+/**
+ * DON'T IMPLEMENT, just use
+ */
+public interface IBlockInteractHandler{
+
+    /**
+     * Returns a boolean[6] of all sides. when true, this side is accessible
+     * @return
+     */
+    public boolean[] getSides();
+
+    public boolean useCount();
+
+    public void decreaseCount(int count);
+
+    public int getRemainingCount();
+
+    /**
+     * When invoked, the drone will abort searching the area. Could be used to abort early when full of RF energy for example, when importing RF.
+     * (It's useless to search any further)
+     */
+    public void abort();
+
+}

--- a/src/api/java/pneumaticCraft/api/drone/ICustomBlockInteract.java
+++ b/src/api/java/pneumaticCraft/api/drone/ICustomBlockInteract.java
@@ -1,0 +1,45 @@
+package pneumaticCraft.api.drone;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.ChunkPosition;
+
+/**
+ * Implement this and register it to PneumaticRegistry.registerCustomBlockInteractor().
+ * This will add a puzzle piece that has only a Area white- and blacklist parameter (similar to a GoTo piece).
+ * It will do the specified behaviour. This can be used to create energy import/export widgets.
+ */
+public interface ICustomBlockInteract{
+
+    /**
+     * Should return a unique Id, used in NBT saving and localization.
+     */
+    public String getName();
+
+    /**
+     * Should return the puzzle piece texture. Should be a multiple of 80x64 (width x height). I'd recommend starting out with copying the Go To widget texture.
+     * @return
+     */
+    public ResourceLocation getTexture();
+
+    /**
+     * The actual interaction.
+     * 
+     * For every position in the selected area the drone will visit every block (ordered from closest to furthest). It will call this method with 'simulate = true'. If this method returns true, the drone will navigate to this location, and call this method again with 'simulate = false' It will keep doing this until this method returns false.
+     * 
+     * When interactHandler.useCount() returns true:
+     * In the interface of the puzzle piece users can specify a 'use count' and fill in the maximum count they want to use. When not simulating, you should only import/export up to interactHandler.getRemainingCount(), and you should notify the removed/added count by doing interactHandler.decreaseCount(int count).
+     * 
+     * @param pos   current visited location
+     * @param drone
+     * @param interactHandler   object you can use to use to get accessible sides and give feedback about counts.
+     * @param simulate  will be true when trying to figure out whether or not the drone should navigate to this block, false when next to this block.
+     * @return
+     */
+    public boolean doInteract(ChunkPosition pos, IDrone drone, IBlockInteractHandler interactHandler, boolean simulate);
+
+    /**
+     * Used for crafting, categorizes the puzzle piece.
+     * @return
+     */
+    public int getCraftingColorIndex();
+}

--- a/src/api/java/pneumaticCraft/api/drone/IDrone.java
+++ b/src/api/java/pneumaticCraft/api/drone/IDrone.java
@@ -1,0 +1,61 @@
+package pneumaticCraft.api.drone;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IExtendedEntityProperties;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.IFluidTank;
+import pneumaticCraft.api.item.IPressurizable;
+
+public interface IDrone extends IPressurizable{
+    /**
+     * 
+     * @param upgradeIndex metadata value of the upgrade item
+     * @return amount of inserted upgrades in the drone
+     */
+    public int getUpgrades(int upgradeIndex);
+
+    public World getWorld();
+
+    public IFluidTank getTank();
+
+    public IInventory getInventory();
+
+    public Vec3 getPosition();
+
+    public IPathNavigator getPathNavigator();
+
+    public void sendWireframeToClient(int x, int y, int z);
+
+    public EntityPlayerMP getFakePlayer();
+
+    public boolean isBlockValidPathfindBlock(int x, int y, int z);
+
+    public void dropItem(ItemStack stack);
+
+    public void setDugBlock(int x, int y, int z);
+
+    public EntityAITasks getTargetAI();
+
+    public IExtendedEntityProperties getProperty(String key);
+
+    public void setProperty(String key, IExtendedEntityProperties property);
+
+    public void setEmittingRedstone(ForgeDirection orientation, int emittingRedstone);
+
+    public void setName(String string);
+
+    public void setCarryingEntity(Entity entity);
+
+    public Entity getCarryingEntity();
+
+    public boolean isAIOverriden();
+
+    public void onItemPickupEvent(EntityItem curPickingUpEntity, int stackSize);
+}

--- a/src/api/java/pneumaticCraft/api/drone/IPathNavigator.java
+++ b/src/api/java/pneumaticCraft/api/drone/IPathNavigator.java
@@ -1,0 +1,11 @@
+package pneumaticCraft.api.drone;
+
+import net.minecraft.entity.Entity;
+
+public interface IPathNavigator{
+    public boolean moveToXYZ(double x, double y, double z);
+
+    public boolean moveToEntity(Entity entity);
+
+    public boolean hasNoPath();
+}

--- a/src/api/java/pneumaticCraft/api/drone/IPathfindHandler.java
+++ b/src/api/java/pneumaticCraft/api/drone/IPathfindHandler.java
@@ -1,0 +1,26 @@
+package pneumaticCraft.api.drone;
+
+import net.minecraft.world.World;
+
+public interface IPathfindHandler{
+    /**
+     * When returned true, the drone can pathfind through this block. When false it can't.
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     * @return
+     */
+    public boolean canPathfindThrough(World world, int x, int y, int z);
+
+    /**
+     * CURRENTLY NOT IMPLEMENTED!
+     * Will be called every tick as long as the drone is < 1 block away from the given coordinate.
+     * can be used to open a door for a drone for example.
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     */
+    public void onPathingThrough(World world, int x, int y, int z);
+}

--- a/src/api/java/pneumaticCraft/api/drone/SpecialVariableRetrievalEvent.java
+++ b/src/api/java/pneumaticCraft/api/drone/SpecialVariableRetrievalEvent.java
@@ -1,0 +1,60 @@
+package pneumaticCraft.api.drone;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.ChunkPosition;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a Drone is trying to get a special coordinate, by accessing a variable with '$' prefix.
+ * These event are posted on the MinecraftForge.EVENT_BUS.
+ */
+public abstract class SpecialVariableRetrievalEvent extends Event{
+
+    /**
+     * The special variable name, with the '$' stripped away.
+     */
+    public final String specialVarName;
+
+    /**
+     * The returning coordinate
+     */
+
+    public SpecialVariableRetrievalEvent(String specialVarName){
+
+        this.specialVarName = specialVarName;
+    }
+
+    public static abstract class CoordinateVariable extends SpecialVariableRetrievalEvent{
+        public ChunkPosition coordinate;
+
+        public CoordinateVariable(String specialVarName){
+            super(specialVarName);
+        }
+
+        public static class Drone extends CoordinateVariable{
+            public final IDrone drone;
+
+            public Drone(IDrone drone, String specialVarName){
+                super(specialVarName);
+                this.drone = drone;
+            }
+        }
+    }
+
+    public static abstract class ItemVariable extends SpecialVariableRetrievalEvent{
+        public ItemStack item;
+
+        public ItemVariable(String specialVarName){
+            super(specialVarName);
+        }
+
+        public static class Drone extends ItemVariable{
+            public final IDrone drone;
+
+            public Drone(IDrone drone, String specialVarName){
+                super(specialVarName);
+                this.drone = drone;
+            }
+        }
+    }
+}

--- a/src/api/java/pneumaticCraft/api/item/IInventoryItem.java
+++ b/src/api/java/pneumaticCraft/api/item/IInventoryItem.java
@@ -1,0 +1,20 @@
+package pneumaticCraft.api.item;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ *  Implement this interface for your items that have an inventory. When you don't have access to the item, just create any old class
+ *  that implements this interface and register an instance of it in PneumaticRegistry.
+ *  This will then will be used in the Pneumatic Helmet's item search.
+ *
+ */
+public interface IInventoryItem{
+
+    /**
+     *  @parm stack: Item that potentially has an inventory.
+     *  @parm curStacks: List of all currently added stacks for this item. Add more stacks in here in your implementation when found the right item.
+     */
+    public void getStacksInItem(ItemStack stack, List<ItemStack> curStacks);
+}

--- a/src/api/java/pneumaticCraft/api/item/IPressurizable.java
+++ b/src/api/java/pneumaticCraft/api/item/IPressurizable.java
@@ -1,0 +1,35 @@
+package pneumaticCraft.api.item;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Any item implementing this interface will be able to (dis)charge in a Charging Station.
+ */
+public interface IPressurizable{
+    /**
+     * This method should return the current pressure of the ItemStack given.
+     * 
+     * @param iStack Stack the pressure is asked from.
+     * @return Pressure in bar.
+     */
+    public float getPressure(ItemStack iStack);
+
+    /**
+     * this method is used to charge or discharge a pneumatic item. when the
+     * value is negative the item should be discharging
+     * 
+     * @param iStack the ItemStack which has to be (dis)charged.
+     * @param amount amount in mL that the item is (dis)charging.
+     */
+    public void addAir(ItemStack iStack, int amount);
+
+    /**
+     * This method should return the maximum pressure of a pneumatic item. If it
+     * has reached this maximum, it won't explode, but it wouldn't (try to)
+     * charge either.
+     * 
+     * @param iStack the stack from which the maximum pressure is asked.
+     * @return maximum pressure in bar.
+     */
+    public float maxPressure(ItemStack iStack);
+}

--- a/src/api/java/pneumaticCraft/api/item/IProgrammable.java
+++ b/src/api/java/pneumaticCraft/api/item/IProgrammable.java
@@ -1,0 +1,34 @@
+package pneumaticCraft.api.item;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Implement this for items that can get programmed in a Programmer.
+ * For now the only thing you can do with this is make program storages, later more interaction with programming puzzles is planned.
+ * Puzzle pieces will be written onto the implementer's itemstack NBT, using the "progWidget" tag.
+ */
+public interface IProgrammable{
+
+    /**
+     * When returned true, this stack is allowed to be programmed.
+     * Used to allow certain damage values to be programmed while others can't.
+     * @param stack
+     * @return
+     */
+    public boolean canProgram(ItemStack stack);
+
+    /**
+     * When returned true, Programming Puzzles are needed to program this item. When returned false, it's free to program.
+     * Drones and Network API's return true in PneumaticCraft, Network Storages return false.
+     * @param stack
+     * @return
+     */
+    public boolean usesPieces(ItemStack stack);
+
+    /**
+     * When returned true, the implementing item will get a tooltip added of the summary of puzzles used in the stored program.
+     * @return
+     */
+    public boolean showProgramTooltip();
+
+}

--- a/src/api/java/pneumaticCraft/api/item/ItemSupplier.java
+++ b/src/api/java/pneumaticCraft/api/item/ItemSupplier.java
@@ -1,0 +1,47 @@
+package pneumaticCraft.api.item;
+
+import net.minecraft.item.Item;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class ItemSupplier{
+    public static Item getItem(String itemName){
+        return GameRegistry.findItem("PneumaticCraft", itemName);
+    }
+
+    /*
+        The following is a list of all the item names that can be passed as argument in getItem(String) to get a PneumaticCraft item.
+     
+        GPSTool                   Currently tracked coordinated is stored in NBT, with 'x', 'y', 'z' being the tag names for the x,y and z positions respectively.
+        machineUpgrade            damage value = upgrade type.
+        ingotIronCompressed
+        pressureGauge
+        stoneBase
+        cannonBarrel
+        turbineBlade
+        plasticPlant              damage value = plant type. Mapped the same as Vanilla dye in terms of color.
+        plastic                   damage value = plastic type. Mapped the same as Vanilla dye in terms of color.
+        airCanister               implements IPressurizable
+        vortexCannon              implements IPressurizable
+        pneumaticCylinder
+        pneumaticHelmet           implements IPressurizable
+        manometer                 implements IPressurizable
+        turbineRotor
+        assemblyProgram           damage value = program type.
+        emptyPCB
+        unassembledPCB
+        PCBBlueprint
+        bucketEtchingAcid
+        transistor
+        capacitor
+        printedCircuitBoard
+        failedPCB
+        networkComponent          damage value = network component type.
+        stopWorm
+        nukeVirus
+        compressedIronGear
+        pneumaticWrench           implements IPressurizable
+
+     
+     
+     */
+}

--- a/src/api/java/pneumaticCraft/api/package-info.java
+++ b/src/api/java/pneumaticCraft/api/package-info.java
@@ -1,0 +1,5 @@
+@API(apiVersion = "1.0", owner = "PneumaticCraft", provides = "PneumaticCraftApi")
+package pneumaticCraft.api;
+
+import cpw.mods.fml.common.API;
+

--- a/src/api/java/pneumaticCraft/api/recipe/AssemblyRecipe.java
+++ b/src/api/java/pneumaticCraft/api/recipe/AssemblyRecipe.java
@@ -1,0 +1,42 @@
+package pneumaticCraft.api.recipe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import pneumaticCraft.api.PneumaticRegistry;
+
+/**
+ * @Deprecated Access via {@link pneumaticCraft.api.recipe.IPneumaticRecipeRegistry}
+ */
+@Deprecated
+public class AssemblyRecipe{
+
+    public static List<AssemblyRecipe> drillRecipes = new ArrayList<AssemblyRecipe>();
+    public static List<AssemblyRecipe> laserRecipes = new ArrayList<AssemblyRecipe>();
+    public static List<AssemblyRecipe> drillLaserRecipes = new ArrayList<AssemblyRecipe>();
+
+    private final ItemStack input;
+    private final ItemStack output;
+
+    public AssemblyRecipe(ItemStack input, ItemStack output){
+        this.input = input;
+        this.output = output;
+    }
+
+    public ItemStack getInput(){
+        return input;
+    }
+
+    public ItemStack getOutput(){
+        return output;
+    }
+
+    public static void addDrillRecipe(Object input, Object output){
+        PneumaticRegistry.getInstance().getRecipeRegistry().addAssemblyDrillRecipe(input, output);
+    }
+
+    public static void addLaserRecipe(Object input, Object output){
+        PneumaticRegistry.getInstance().getRecipeRegistry().addAssemblyLaserRecipe(input, output);
+    }
+}

--- a/src/api/java/pneumaticCraft/api/recipe/IPneumaticRecipeRegistry.java
+++ b/src/api/java/pneumaticCraft/api/recipe/IPneumaticRecipeRegistry.java
@@ -1,0 +1,80 @@
+package pneumaticCraft.api.recipe;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Interface accessed via PneumaticRegistry.getInstance().getRecipeRegistry(), used to register recipes to PneumaticCraft.
+ * @author MineMaarten
+ */
+public interface IPneumaticRecipeRegistry{
+    /**
+     * 
+     * @param requiredFluid can be null
+     * @param requiredItem can be null
+     * @param requiredTemperature in degrees Kelvin.
+     * @param requiredPressure required pressure.
+     * @param output the output of the recipe. cannot be null.
+     */
+    public void registerThermopneumaticProcessingPlantRecipe(FluidStack requiredFluid, ItemStack requiredItem, FluidStack output, double requiredTemperature, float requiredPressure);
+
+    /**
+     * Allows for registry of a recipe which allows for all your custom needs.
+     * @param recipe
+     */
+    public void registerThermopneumaticProcessingPlantRecipe(IThermopneumaticProcessingPlantRecipe recipe);
+
+    /**
+     * Add a recipe that needs an item to be drilled in an Assembly set-up to get the output.
+     * @param input valid types: Block, Item, ItemStack
+     * @param output valid types: Block, Item, ItemStack
+     */
+    public void addAssemblyDrillRecipe(Object input, Object output);
+
+    /**
+     * Add a recipe that needs an item to be lasered in an Assembly set-up to get the output.
+     * @param input valid types: Block, Item, ItemStack
+     * @param output valid types: Block, Item, ItemStack
+     */
+    public void addAssemblyLaserRecipe(Object input, Object output);
+
+    /**
+     * Adds a recipe to the Pressure Chamber.
+     * @param input , either of type ItemStack or Pair<String, Integer>, where the String is the Ore dictionary entry and Integer is the amount (stack size)
+     * @param pressureRequired negative pressures for negative pressure needs.
+     * @param output
+     */
+    public void registerPressureChamberRecipe(Object[] input, float pressureRequired, ItemStack[] output);
+
+    /**
+     * Allows for registry of a recipe which allows for all your custom needs.
+     * @param recipe
+     */
+    public void registerPressureChamberRecipe(IPressureChamberRecipe recipe);
+
+    /**
+     * Adds an Amadron offer. Both the input and output can either be ItemStack or FluidStack. An exception will be thrown if this is not the case.
+     * This is a default offer, meaning it will be put in a clean config load. After that the user can change it at will to remove this added recipe.
+     * It's a static offer, meaning if it exists in the instance, it will be there forever (like the Emerald --> PCB Blueprint offer).
+     * @param input
+     * @param output
+     */
+    public void registerDefaultStaticAmadronOffer(Object input, Object output);
+
+    /**
+     * Adds an Amadron offer. Both the input and output can either be ItemStack or FluidStack. An exception will be thrown if this is not the case.
+     * This is a default offer, meaning it will be put in a clean config load. After that the user can change it at will to remove this added recipe.
+     * It's a periodic offer, meaning it will be shuffled (by default) once per day between other periodic offers, like the villager trade offers.
+     * @param input
+     * @param output
+     */
+    void registerDefaultPeriodicAmadronOffer(Object input, Object output);
+
+    /**
+     * Adds a behaviour for when an inventory is framed with a Heat Frame, and is cooled below 0 degrees C. If the input item is a container item it will be returned as well.
+     * @param input either of type ItemStack or Pair<String, Integer>, where the String is the Ore dictionary entry and Integer is the amount (stack size)
+     * @param output
+     */
+    public void registerHeatFrameCoolRecipe(Object input, ItemStack output);
+
+}

--- a/src/api/java/pneumaticCraft/api/recipe/IPressureChamberRecipe.java
+++ b/src/api/java/pneumaticCraft/api/recipe/IPressureChamberRecipe.java
@@ -1,0 +1,34 @@
+package pneumaticCraft.api.recipe;
+
+import net.minecraft.item.ItemStack;
+
+public interface IPressureChamberRecipe{
+
+    /**
+     * Returns the threshold which is minimal to craft the recipe. Negative pressures also work.
+     * @return threshold pressure
+     */
+    public float getCraftingPressure();
+
+    /**
+     * This method should return the used items in the recipe when the right items are provided to craft this recipe.
+     * @param inputStacks
+     * @return usedStacks, return null when the inputStacks aren't valid for this recipe.
+     */
+    public ItemStack[] isValidRecipe(ItemStack[] inputStacks);
+
+    /**
+     * When returned true, only the exact same references of the stacks returned by isValidRecipe() will be removed. This is useful
+     * to remove stacks with a certain NBT value (like Enchanted Books). Return false for normal behaviour.
+     * @return true if exact stacks should be removed only.
+     */
+    public boolean shouldRemoveExactStacks();
+
+    /**
+     * This method will be called when the recipe should output its items. the stacks the recipe output, may be dependent on the input stacks.
+     * @param removedStacks same reference to the stacks returned by isValidRecipe.
+     * @param inputStacks. These stacks can be modified (like adding/removing NBT data eg.)
+     * @return outputStacks. Stacks that will pop 'out of the chamber'
+     */
+    public ItemStack[] craftRecipe(ItemStack[] inputStacks, ItemStack[] removedStacks);
+}

--- a/src/api/java/pneumaticCraft/api/recipe/IThermopneumaticProcessingPlantRecipe.java
+++ b/src/api/java/pneumaticCraft/api/recipe/IThermopneumaticProcessingPlantRecipe.java
@@ -1,0 +1,43 @@
+package pneumaticCraft.api.recipe;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+public interface IThermopneumaticProcessingPlantRecipe{
+    /**
+     * Should return true when this recipe is valid, providing the input items. Do not modify these input items yet.
+     * @param inputTank
+     * @param inputItem
+     * @return
+     */
+    public boolean isValidRecipe(FluidStack inputTank, ItemStack inputItem);
+
+    /**
+     * Should return the output fluid stack for this recipe. Do not modify these input items yet.
+     * @param inputTank
+     * @param inputItem
+     * @return
+     */
+    public FluidStack getRecipeOutput(FluidStack inputTank, ItemStack inputItem);
+
+    /**
+     * Decrease the input items used in the recipe here. When the stacksize is decreased to 0 it will automatically be set to null, so you don't have to worry about that.
+     * @param inputTank
+     * @param inputItem
+     */
+    public void useRecipeItems(FluidStack inputTank, ItemStack inputItem);
+
+    /**
+     * 
+     * @param inputTank
+     * @param inputItem
+     * @return temperature in degrees Kelvin.
+     */
+    public double getRequiredTemperature(FluidStack inputTank, ItemStack inputItem);
+
+    public double heatUsed(FluidStack inputTank, ItemStack inputItem);
+
+    public float getRequiredPressure(FluidStack inputTank, ItemStack inputItem);
+
+    public int airUsed(FluidStack inputTank, ItemStack inputItem);
+}

--- a/src/api/java/pneumaticCraft/api/recipe/PressureChamberRecipe.java
+++ b/src/api/java/pneumaticCraft/api/recipe/PressureChamberRecipe.java
@@ -1,0 +1,42 @@
+package pneumaticCraft.api.recipe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * @Deprecated Access via {@link pneumaticCraft.api.recipe.IPneumaticRecipeRegistry}
+ */
+@Deprecated
+public class PressureChamberRecipe{
+    public static List<PressureChamberRecipe> chamberRecipes = new ArrayList<PressureChamberRecipe>();
+    public static List<IPressureChamberRecipe> specialRecipes = new ArrayList<IPressureChamberRecipe>();
+
+    public final Object[] input;
+    public final ItemStack[] output;
+    public final float pressure;
+
+    @Deprecated
+    public PressureChamberRecipe(ItemStack[] input, float pressureRequired, ItemStack[] output, boolean outputAsBlock){
+        this.input = input;
+        this.output = output;
+        pressure = pressureRequired;
+    }
+
+    public PressureChamberRecipe(Object[] input, float pressureRequired, ItemStack[] output){
+        for(Object o : input) {
+            if(!(o instanceof ItemStack) && !(o instanceof Pair)) throw new IllegalArgumentException("Input objects need to be of type ItemStack or (Apache's) Pair<String, Integer>. Violating object: " + o);
+            if(o instanceof Pair) {
+                Pair pair = (Pair)o;
+                if(!(pair.getKey() instanceof String)) throw new IllegalArgumentException("Pair key needs to be a String (ore dict entry)");
+                if(!(pair.getValue() instanceof Integer)) throw new IllegalArgumentException("Value key needs to be an Integer (amount)");
+            }
+        }
+        this.input = input;
+        this.output = output;
+        pressure = pressureRequired;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/AirHandlerSupplier.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/AirHandlerSupplier.java
@@ -1,0 +1,51 @@
+package pneumaticCraft.api.tileentity;
+
+import java.lang.reflect.Constructor;
+
+public class AirHandlerSupplier{
+    private static Constructor airHandlerConstructor;
+
+    public static IAirHandler getTierOneAirHandler(int volume){
+        return getAirHandler(5F, 7F, volume);
+    }
+
+    public static IAirHandler getTierTwoAirHandler(int volume){
+        return getAirHandler(20F, 25F, volume);
+    }
+
+    /**
+     * Returns a new instance of an IAirHandler. This handler handles everything pressurized air related: Air dispersion,
+     * blowing up when the pressure gets too high, providing a method for releasing air into the atmosphere...
+     * PROVIDED THAT THE FOLLOWING METHODS ARE FORWARDED TO THIS INSTANCE:
+     * {@link net.minecraft.tileentity.TileEntity#updateEntity()}, 
+     * {@link net.minecraft.tileentity.TileEntity#writeToNBT(net.minecraft.nbt.NBTTagCompound)}
+     * {@link net.minecraft.tileentity.TileEntity#readFromNBT(net.minecraft.nbt.NBTTagCompound)}
+     * {@link net.minecraft.tileentity.TileEntity#validate()}
+     * @param dangerPressure minimal pressure on which this machine can explode (the yellow to red transition)
+     * @param criticalPressure the absolute maximum pressure the machine can take 7 bar in tier 1 machines.
+     * @param maxFlow maximum mL/tick that this machine can disperse. Tier one machines do 50mL/tick while Tier two have 200mL/tick.
+     * @param volume Volume of the machine's internal storage. These vary from 1000mL for small machines to 10,000mL for the big ones.
+     * The higher the volume the slower the machine will charge/discharge.
+     * @return
+     */
+    public static IAirHandler getAirHandler(float dangerPressure, float criticalPressure, int volume){
+        IAirHandler airHandler = null;
+        try {
+            if(airHandlerConstructor == null) airHandlerConstructor = Class.forName("pneumaticCraft.common.tileentity.TileEntityPneumaticBase").getConstructor(float.class, float.class, int.class);
+            airHandler = (IAirHandler)airHandlerConstructor.newInstance(dangerPressure, criticalPressure, volume);
+        } catch(Exception e) {
+            System.err.println("[PneumaticCraft API] An error has occured whilst trying to get an AirHandler. Here's a stacktrace:");
+            e.printStackTrace();
+        }
+        return airHandler;
+    }
+
+    /**
+     * Use the version with integer parameters
+     */
+    @Deprecated
+    public static IAirHandler getAirHandler(float dangerPressure, float criticalPressure, float maxFlow, float volume){
+        return getAirHandler(dangerPressure, criticalPressure, (int)volume);
+    }
+
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/HeatBehaviour.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/HeatBehaviour.java
@@ -1,0 +1,117 @@
+package pneumaticCraft.api.tileentity;
+
+import net.minecraft.block.Block;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import pneumaticCraft.api.IHeatExchangerLogic;
+
+/**
+ * Extend this class, and register it via {@link PneumaticRegistry.getInstance().registerHeatBehaviour()}
+ * This can be used to add heat dependent logic to non-TE's or blocks you don't have access to. PneumaticCraft uses this to power Furnaces with heat,
+ * and to turn Lava into Obsidian when heat is drained. This only works for ticking heat logic, so not for static heat sources like lava blocks.
+ */
+public abstract class HeatBehaviour<Tile extends TileEntity> {
+
+    private IHeatExchangerLogic connectedHeatLogic;
+    private World world;
+    private int x, y, z;
+    private Tile cachedTE;
+    private Block block;
+
+    /**
+     * Called by the connected IHeatExchangerLogic.
+     * @param connectedHeatLogic
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     */
+    public void initialize(IHeatExchangerLogic connectedHeatLogic, World world, int x, int y, int z){
+        this.connectedHeatLogic = connectedHeatLogic;
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        cachedTE = null;
+        block = null;
+    }
+
+    public IHeatExchangerLogic getHeatExchanger(){
+        return connectedHeatLogic;
+    }
+
+    public World getWorld(){
+        return world;
+    }
+
+    public int getX(){
+        return x;
+    }
+
+    public int getY(){
+        return y;
+    }
+
+    public int getZ(){
+        return z;
+    }
+
+    public Tile getTileEntity(){
+        if(cachedTE == null || cachedTE.isInvalid()) cachedTE = (Tile)world.getTileEntity(x, y, z);
+        return cachedTE;
+    }
+
+    public Block getBlock(){
+        if(block == null) block = world.getBlock(x, y, z);
+        return block;
+    }
+
+    /**
+     * Unique id for this behaviour. Used in NBT saving. I recommend prefixing it with your modid.
+     * @return
+     */
+    public abstract String getId();
+
+    /**
+     * Return true when this heat behaviour is applicable for this coordinate. World access methods can be used here (getWorld(), getX(), getY(), getZ(), getBlock(), getTileEntity()).
+     * @return
+     */
+    public abstract boolean isApplicable();
+
+    /**
+     * Called every tick to update this behaviour.
+     */
+    public abstract void update();
+
+    public void writeToNBT(NBTTagCompound tag){
+        tag.setInteger("x", x);
+        tag.setInteger("y", y);
+        tag.setInteger("z", z);
+    }
+
+    public void readFromNBT(NBTTagCompound tag){
+        x = tag.getInteger("x");
+        y = tag.getInteger("y");
+        z = tag.getInteger("z");
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(o instanceof HeatBehaviour) {
+            HeatBehaviour behaviour = (HeatBehaviour)o;
+            return behaviour.getId().equals(getId()) && behaviour.getX() == getX() && behaviour.getY() == getY() && behaviour.getZ() == getZ();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode(){
+        int i = getId().hashCode();
+        i = i * 31 + getX();
+        i = i * 31 + getY();
+        i = i * 31 + getZ();
+        return i;
+    }
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/IAirHandler.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/IAirHandler.java
@@ -1,0 +1,126 @@
+package pneumaticCraft.api.tileentity;
+
+import java.util.List;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A way for you to access about everything you need from a pneumatic machine.
+ * DO NOT IMPLEMENT THIS YOURSELF! Use AirHandlerSupplier to get an instance for your TileEntity, and implement IPneumaticMachine instead.
+ */
+
+public interface IAirHandler extends IManoMeasurable{
+
+    /**
+     * -----------Needs to be forwarded by the implementing TileEntity's updateEntity() method.
+     * Updates the pneumatic machine's logic like air dispersion and checking if it needs to explode.
+     */
+    public void updateEntityI();
+
+    /**
+     * -----------Needs to be forwarded by the implementing TileEntity.
+     * @param nbt
+     */
+    public void readFromNBTI(NBTTagCompound nbt);
+
+    /**
+     * -----------Needs to be forwarded by the implementing TileEntity.
+     * @param nbt
+     */
+    public void writeToNBTI(NBTTagCompound nbt);
+
+    /**
+     * -----------Needs to be forwarded by the implementing TileEntity with itself as parameter.
+     * @param parent TileEntity that is referencing this air handler.
+     */
+    public void validateI(TileEntity parent);
+
+    /**
+     * Method to release air in the air. It takes air from a specific side, plays a sound effect, and spawns smoke particles.
+     * It automatically detects if it needs to release air (when under pressure), suck air (when in vacuum) or do nothing.
+     * @param side
+     */
+    public void airLeak(ForgeDirection side);
+
+    /**
+     * Returns a list of all the connecting pneumatics. It takes sides in account.
+     */
+    public List<Pair<ForgeDirection, IAirHandler>> getConnectedPneumatics();
+
+    /**
+     * Adds air to the tank of the given side of this TE. It also updates clients where needed (when they have a GUI opened).
+     * Deprecated: use the version with the integer parameter now.
+     * @param amount
+     * @param side
+     */
+    @Deprecated
+    public void addAir(float amount, ForgeDirection side);
+
+    public void addAir(int amount, ForgeDirection side);
+
+    /**
+     * Sets the volume of this TE's air tank. When the volume decreases the pressure will remain the same, meaning air will
+     * be lost. When the volume increases, the air remains the same, meaning the pressure will drop.
+     * Used in the Volume Upgrade calculations.
+     * Deprecated: use the version with the integer parameter now.
+     * @param newVolume
+     */
+    @Deprecated
+    public void setVolume(float newVolume);
+
+    public void setVolume(int newVolume);
+
+    public int getVolume();
+
+    /**
+     * Returns the pressure at which this TE will explode.
+     * @return
+     */
+    public float getMaxPressure();
+
+    public float getPressure(ForgeDirection sideRequested);
+
+    /**
+     * Returns the amount of air (that has a relation to the pressure: air = pressure * volume)
+     * @param sideRequested
+     * @return
+     */
+    public int getCurrentAir(ForgeDirection sideRequested);
+
+    /**
+     * When your TileEntity is implementing IInventory and has slots that accept PneumaticCraft upgrades, register these slots
+     * to the air handler by calling this method once on initialization of the TileEntity. Then they'll automatically be used to get Volume/Security upgrades.
+     * @param upgradeSlots all upgrade slots stored in an array.
+     */
+    public void setUpgradeSlots(int... upgradeSlots);
+
+    public int[] getUpgradeSlots();
+
+    public int getXCoord();
+
+    public int getYCoord();
+
+    public int getZCoord();
+
+    /**
+     * Needs to be forwarded from the implementing _Block_! Forward the Block's "onNeighborChange" method to this handler.
+     */
+    public void onNeighborChange();
+
+    /**
+     * Creates an air connection with another handler. Can be used to connect up pneumatic machines that aren't neighboring, like AE2's P2P tunnels.
+     * @param otherHandler
+     */
+    public void createConnection(IAirHandler otherHandler);
+
+    /**
+     * Remove a connection created with createConnection. You need to call this when one of the hosts of this IAirHandlers is invalidated.
+     * @param otherHandler
+     */
+    public void removeConnection(IAirHandler otherHandler);
+
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/IHeatExchanger.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/IHeatExchanger.java
@@ -1,0 +1,24 @@
+package pneumaticCraft.api.tileentity;
+
+import net.minecraftforge.common.util.ForgeDirection;
+import pneumaticCraft.api.IHeatExchangerLogic;
+
+/**
+ * Implemented by TileEntities or Blocks which transport heat. Keep in mind that when a Block is implementing it you only can give off a constant
+ * resistance/temperature (like Lava and Ice).
+ * @author MineMaarten
+ * www.minemaarten.com
+ */
+public interface IHeatExchanger{
+
+    /**
+     * Get an instance of IHeatExchangerLogic from PneumaticRegistry.getInstance().getHeatExchangerLogic() and keep a global reference.
+     * Then return it in this method. You can return different exchanger logics for different sides. Keep in mind that when you change
+     * a returned logic, you need to create a neighbor block change to notify the differences. You can return null to indicate no heat can
+     * be exchanged on that side.
+     * @param side
+     * @return
+     */
+    public IHeatExchangerLogic getHeatExchangerLogic(ForgeDirection side);
+
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/IManoMeasurable.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/IManoMeasurable.java
@@ -1,0 +1,14 @@
+package pneumaticCraft.api.tileentity;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+public interface IManoMeasurable{
+    /**
+     * This method is invoked by the Manometer when a player right-clicks a TE or Entity with this interface implemented.
+     * @param player that rightclicks the measurable TE, and therefore needs to get the message
+     * @param curInfo list you can append info to. If you don't append any info no air will be used.
+     */
+    public void printManometerMessage(EntityPlayer player, List<String> curInfo);
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/IPneumaticMachine.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/IPneumaticMachine.java
@@ -1,0 +1,34 @@
+package pneumaticCraft.api.tileentity;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Deprecated: Use ISidedPneumaticMachine in favor of this one. In Minecraft 1.8+ that ISidedPneumaticMachine will be renamed to IPneumaticMachine, and therefore will be sided by default.
+ */
+@Deprecated
+public interface IPneumaticMachine{
+
+    /**
+     * In your TileEntity class which is implementing this interface you should keep a reference of an IAirHandler.
+     * You can retrieve one by calling {@link AirHandlerSupplier#getAirHandler(net.minecraft.tileentity.TileEntity, float, float, float, float)}.
+     * Do this when your TileEntity is initialized, i.e. xCoord,yCoord,zCoord and worldObj have a value. 
+     * In this method you need to return this reference.
+     * 
+     * IMPORTANT: You need to forward the {@link net.minecraft.tileentity.TileEntity#updateEntity()}, 
+     * {@link net.minecraft.tileentity.TileEntity#writeToNBT(net.minecraft.nbt.NBTTagCompound)} , 
+     * {@link net.minecraft.tileentity.TileEntity#readFromNBT(net.minecraft.nbt.NBTTagCompound)} and
+     * {@link net.minecraft.tileentity.TileEntity#validate()} (with the implementing TileEntity as additional parameter)
+     * to the IAirHandler.
+     * Apart from that you'll need to forward {@link net.minecraft.block.Block#onNeighborChange(net.minecraft.world.IBlockAccess, int, int, int, int, int, int)}
+     * from the implementing block to the IAirHandler.
+     * @return
+     */
+    public IAirHandler getAirHandler();
+
+    /**
+     * Returns true if the pneumatic logic is connected to the given side.
+     * @param side
+     * @return
+     */
+    public boolean isConnectedTo(ForgeDirection side);
+}

--- a/src/api/java/pneumaticCraft/api/tileentity/ISidedPneumaticMachine.java
+++ b/src/api/java/pneumaticCraft/api/tileentity/ISidedPneumaticMachine.java
@@ -1,0 +1,23 @@
+package pneumaticCraft.api.tileentity;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface ISidedPneumaticMachine{
+
+    /**
+     * In your TileEntity class which is implementing this interface you should keep a reference of an IAirHandler.
+     * You can retrieve one by calling {@link AirHandlerSupplier#getAirHandler(net.minecraft.tileentity.TileEntity, float, float, float, float)}.
+     * Do this when your TileEntity is initialized, i.e. xCoord,yCoord,zCoord and worldObj have a value. 
+     * In this method you need to return this reference.
+     * 
+     * IMPORTANT: You need to forward the {@link net.minecraft.tileentity.TileEntity#updateEntity()}, 
+     * {@link net.minecraft.tileentity.TileEntity#writeToNBT(net.minecraft.nbt.NBTTagCompound)} , 
+     * {@link net.minecraft.tileentity.TileEntity#readFromNBT(net.minecraft.nbt.NBTTagCompound)} and
+     * {@link net.minecraft.tileentity.TileEntity#validate()} (with the implementing TileEntity as additional parameter)
+     * to the IAirHandler.
+     * Apart from that you'll need to forward {@link net.minecraft.block.Block#onNeighborChange(net.minecraft.world.IBlockAccess, int, int, int, int, int, int)}
+     * from the implementing block to the IAirHandler.
+     * @return a valid IAirHandler when connectable on this side. If not, return null.
+     */
+    public IAirHandler getAirHandler(ForgeDirection side);
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/EntityPollSensor.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/EntityPollSensor.java
@@ -1,0 +1,32 @@
+package pneumaticCraft.api.universalSensor;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+public abstract class EntityPollSensor implements IPollSensorSetting{
+
+    @Override
+    public String getSensorPath(){
+        return "entityTracker";
+    }
+
+    @Override
+    public int getPollFrequency(TileEntity te){
+        return 1;
+    }
+
+    @Override
+    public int getRedstoneValue(World world, int x, int y, int z, int sensorRange, String textBoxText){
+        AxisAlignedBB aabb = AxisAlignedBB.getBoundingBox(x - sensorRange, y - sensorRange, z - sensorRange, x + 1 + sensorRange, y + 1 + sensorRange, z + 1 + sensorRange);
+        return getRedstoneValue(world.getEntitiesWithinAABB(getEntityTracked(), aabb), textBoxText);
+    }
+
+    public abstract Class getEntityTracked();
+
+    public abstract int getRedstoneValue(List<Entity> entities, String textBoxText);
+
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/IBlockAndCoordinateEventSensor.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/IBlockAndCoordinateEventSensor.java
@@ -1,0 +1,59 @@
+package pneumaticCraft.api.universalSensor;
+
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkPosition;
+
+import org.lwjgl.util.Rectangle;
+
+import cpw.mods.fml.common.eventhandler.Event;
+
+public interface IBlockAndCoordinateEventSensor{
+    /**
+     * See {@link ISensorSetting#getSensorPath()}
+     * @return
+     */
+    public String getSensorPath();
+
+    /**
+     * Extended version of the normal emitRedstoneOnEvent. This method will only invoke with a valid GPS tool, and when all the coordinates are within range.
+     * @param event
+     * @param sensor
+     * @param range
+     * @param positions When only one GPS Tool is inserted this contains the position of just that tool. If two GPS Tools are inserted, These are both corners of a box, and every coordinate in this box is added to the positions argument.
+     * @return
+     */
+    public int emitRedstoneOnEvent(Event event, TileEntity sensor, int range, Set<ChunkPosition> positions);
+
+    /**
+     * See {@link IEventSensorSetting#getRedstonePulseLength()}
+     * @return
+     */
+    public int getRedstonePulseLength();
+
+    /**
+     * See {@link ISensorSetting#needsTextBox()}
+     * @return
+     */
+    public boolean needsTextBox();
+
+    /**
+     * See {@link ISensorSetting#needsSlot()}
+     */
+    public Rectangle needsSlot();
+
+    /**
+     * See {@link ISensorSetting#getDescription()}
+     * @return
+     */
+    public List<String> getDescription();
+
+    /**
+     * Called by GuiScreen#drawScreen this method can be used to render additional things like status/info text.
+     * @param fontRenderer
+     */
+    public void drawAdditionalInfo(FontRenderer fontRenderer);
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/IBlockAndCoordinatePollSensor.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/IBlockAndCoordinatePollSensor.java
@@ -1,0 +1,64 @@
+package pneumaticCraft.api.universalSensor;
+
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.ChunkPosition;
+import net.minecraft.world.World;
+
+import org.lwjgl.util.Rectangle;
+
+public interface IBlockAndCoordinatePollSensor{
+    /**
+     * See {@link ISensorSetting#getSensorPath()}
+     * @return
+     */
+    public String getSensorPath();
+
+    /**
+     * See {@link ISensorSetting#needsTextBox()}
+     * @return
+     */
+    public boolean needsTextBox();
+
+    /**
+     * See {@link ISensorSetting#needsSlot()}
+     * @return
+     */
+    public Rectangle needsSlot();
+
+    /**
+     * See {@link ISensorSetting#getDescription()}
+     * @return
+     */
+    public List<String> getDescription();
+
+    /**
+     * See {@link IPollSensorSetting#getRedstoneValue(World, int, int, int, int, String)} , but this has the GPS tracked coordinates
+     * as extra parameters. This method will only invoke with a valid GPS tool, and when all the coordinates are within range.
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     * @param sensorRange
+     * @param textBoxText
+     * @param positions When only one GPS Tool is inserted this contains the position of just that tool. If two GPS Tools are inserted, These are both corners of a box, and every coordinate in this box is added to the positions argument.
+     * @return
+     */
+    public int getRedstoneValue(World world, int x, int y, int z, int sensorRange, String textBoxText, Set<ChunkPosition> positions);
+
+    /**
+     * See {@link IPollSensorSetting#getPollFrequency(TileEntity)}
+     * @return
+     */
+    public int getPollFrequency();
+
+    /**
+     * Called by GuiScreen#drawScreen this method can be used to render additional things like status/info text.
+     * @param fontRenderer
+     */
+    public void drawAdditionalInfo(FontRenderer fontRenderer);
+
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/IEventSensorSetting.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/IEventSensorSetting.java
@@ -1,0 +1,23 @@
+package pneumaticCraft.api.universalSensor;
+
+import net.minecraft.tileentity.TileEntity;
+import cpw.mods.fml.common.eventhandler.Event;
+
+public interface IEventSensorSetting extends ISensorSetting{
+
+    /**
+     * This method is only invoked when a subscribed event is triggered.
+     * @param event
+     * @param sensor
+     * @param range
+     * @param textboxText
+     * @return Redstone strength for the given event.
+     */
+    public int emitRedstoneOnEvent(Event event, TileEntity sensor, int range, String textboxText);
+
+    /**
+     * Should return how long a pulse should hold in ticks. By default this is 5 ticks (1/4 second).
+     * @return
+     */
+    public int getRedstonePulseLength();
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/IPollSensorSetting.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/IPollSensorSetting.java
@@ -1,0 +1,29 @@
+package pneumaticCraft.api.universalSensor;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public interface IPollSensorSetting extends ISensorSetting{
+
+    /**
+     * The value returned here is the interval between every check in ticks (the interval of calling getRedstoneValue()).
+     * Consider increasing the interval when your sensor method is resource intensive.
+     * @param te universal sensor
+     * @return
+     */
+    public int getPollFrequency(TileEntity te);
+
+    /**
+     * The base method. This method should return the outputted redstone value 0-15 of this sensor. When this sensor is
+     * digital, just return 0 or 15.
+     * @param world
+     * @param x
+     * @param y
+     * @param z
+     * @param sensorRange Range of the sensor, based on the amount of Range Upgrades inserted in the Universal Sensor.
+     * @param textBoxText The text typed in the textbox of the Universal Sensor.
+     * @return
+     */
+    public int getRedstoneValue(World world, int x, int y, int z, int sensorRange, String textBoxText);
+
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/ISensorSetting.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/ISensorSetting.java
@@ -1,0 +1,59 @@
+package pneumaticCraft.api.universalSensor;
+
+import java.util.List;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import org.lwjgl.util.Rectangle;
+
+public interface ISensorSetting{
+    /**
+     * Should return the button path the player has to follow in which this setting is stored.
+     * For instance, when the sensor should be located in player and is called speed, you should return "entityTracker/player/speed".
+     * "entityTracker" indicates that this sensor needs an Entity Tracker upgrade to run. You can choose from the following upgrades:
+     * 
+     * -entityTracker
+     * -blockTracker
+     * -gpsTool  (so you can use a certain coordinate (within range) to measure on)
+     * -volume
+     * -dispenser
+     * -speed
+     * -itemLife
+     * -itemSearch
+     * -coordinateTracker
+     * -range
+     * -security
+     * 
+     * You can allow only sensors to work by more than one upgrade, by seperating the upgrades with a '_'. For example,
+     * "entityTracker_speed" will only let the sensor be chosen when both an Entity Tracker and a Speed Upgrade are inserted.
+     * @return
+     */
+    public String getSensorPath();
+
+    /**
+     * When returned true, the GUI will enable the textbox writing, otherwise not.
+     * @return
+     */
+    public boolean needsTextBox();
+
+    /**
+     * Called by GuiScreen#drawScreen this method can be used to render additional things like status/info text.
+     * @param fontRenderer
+     */
+    public void drawAdditionalInfo(FontRenderer fontRenderer);
+
+    /**
+     * Should return the description of this sensor displayed in the GUI stat. Information should at least include
+     * when this sensor emits redstone and how (analog (1 through 15), or digital).
+     * @return
+     */
+    public List<String> getDescription();
+
+    /**
+     * Not being used at the moment, I recommend returning null for now. It is going to be used to allow sensors to decide their
+     * status on a item which can be inserted in a slot in the GUI if this method returns a rectangle with the coordinates of
+     * the slot.
+     * @return
+     */
+    public Rectangle needsSlot();
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/PlayerEventSensor.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/PlayerEventSensor.java
@@ -1,0 +1,33 @@
+package pneumaticCraft.api.universalSensor;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import cpw.mods.fml.common.eventhandler.Event;
+
+public abstract class PlayerEventSensor implements IEventSensorSetting{
+
+    @Override
+    public String getSensorPath(){
+        return "entityTracker/Player";
+    }
+
+    @Override
+    public int emitRedstoneOnEvent(Event event, TileEntity sensor, int range, String textboxText){
+        if(event instanceof PlayerEvent) {
+            EntityPlayer player = ((PlayerEvent)event).entityPlayer;
+            if(Math.abs(player.posX - sensor.xCoord + 0.5D) < range + 0.5D && Math.abs(player.posY - sensor.yCoord + 0.5D) < range + 0.5D && Math.abs(player.posZ - sensor.zCoord + 0.5D) < range + 0.5D) {
+                return emitRedstoneOnEvent((PlayerEvent)event, sensor, range);
+            }
+        }
+        return 0;
+    }
+
+    public abstract int emitRedstoneOnEvent(PlayerEvent event, TileEntity sensor, int range);
+
+    @Override
+    public int getRedstonePulseLength(){
+        return 5;
+    }
+
+}

--- a/src/api/java/pneumaticCraft/api/universalSensor/SensorRegistrator.java
+++ b/src/api/java/pneumaticCraft/api/universalSensor/SensorRegistrator.java
@@ -1,0 +1,33 @@
+package pneumaticCraft.api.universalSensor;
+
+/**
+ * With this class you can register your own sensors.
+ */
+public class SensorRegistrator{
+    /**
+     * This field will be initialized in the PreInit phase of PneumaticCraft's loading phase.
+     * With this field you can register every Universal Sensor sensor you want. Just pass a new instance
+     * to one of the registerSensor methods. Sensors are singletons.
+     */
+    public static ISensorRegistrator sensorRegistrator;
+
+    public static interface ISensorRegistrator{
+        /**
+         * Registry for IPollSensorSetting, EntityPollSensor and IEventSensorSetting, and any other instance of ISensorSetting.
+         * @param sensor
+         */
+        public void registerSensor(ISensorSetting sensor);
+
+        /**
+         * Registry for IBlockAndCoordinateEventSensor
+         * @param sensor
+         */
+        public void registerSensor(IBlockAndCoordinateEventSensor sensor);
+
+        /**
+         * Registry for IBlockAndCoordinatePollSensor
+         * @param sensor
+         */
+        public void registerSensor(IBlockAndCoordinatePollSensor sensor);
+    }
+}

--- a/src/api/java/thaumcraft/api/BlockCoordinates.java
+++ b/src/api/java/thaumcraft/api/BlockCoordinates.java
@@ -1,0 +1,108 @@
+package thaumcraft.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+public class BlockCoordinates implements Comparable
+{
+    public int x;
+
+    /** the y coordinate */
+    public int y;
+
+    /** the z coordinate */
+    public int z;
+
+    public BlockCoordinates() {}
+
+    public BlockCoordinates(int par1, int par2, int par3)
+    {
+        this.x = par1;
+        this.y = par2;
+        this.z = par3;
+    }
+    
+    public BlockCoordinates(TileEntity tile)
+    {
+        this.x = tile.xCoord;
+        this.y = tile.yCoord;
+        this.z = tile.zCoord;
+    }
+
+    public BlockCoordinates(BlockCoordinates par1ChunkCoordinates)
+    {
+        this.x = par1ChunkCoordinates.x;
+        this.y = par1ChunkCoordinates.y;
+        this.z = par1ChunkCoordinates.z;
+    }
+
+    public boolean equals(Object par1Obj)
+    {
+        if (!(par1Obj instanceof BlockCoordinates))
+        {
+            return false;
+        }
+        else
+        {
+        	BlockCoordinates coordinates = (BlockCoordinates)par1Obj;
+            return this.x == coordinates.x && this.y == coordinates.y && this.z == coordinates.z ;
+        }
+    }
+
+    public int hashCode()
+    {
+        return this.x + this.y << 8 + this.z << 16;
+    }
+
+    /**
+     * Compare the coordinate with another coordinate
+     */
+    public int compareWorldCoordinate(BlockCoordinates par1)
+    {
+        return this.y == par1.y ? (this.z == par1.z ? this.x - par1.x : this.z - par1.z) : this.y - par1.y;
+    }
+
+    public void set(int par1, int par2, int par3, int d)
+    {
+        this.x = par1;
+        this.y = par2;
+        this.z = par3;
+    }
+
+    /**
+     * Returns the squared distance between this coordinates and the coordinates given as argument.
+     */
+    public float getDistanceSquared(int par1, int par2, int par3)
+    {
+        float f = (float)(this.x - par1);
+        float f1 = (float)(this.y - par2);
+        float f2 = (float)(this.z - par3);
+        return f * f + f1 * f1 + f2 * f2;
+    }
+
+    /**
+     * Return the squared distance between this coordinates and the ChunkCoordinates given as argument.
+     */
+    public float getDistanceSquaredToWorldCoordinates(BlockCoordinates par1ChunkCoordinates)
+    {
+        return this.getDistanceSquared(par1ChunkCoordinates.x, par1ChunkCoordinates.y, par1ChunkCoordinates.z);
+    }
+
+    public int compareTo(Object par1Obj)
+    {
+        return this.compareWorldCoordinate((BlockCoordinates)par1Obj);
+    }
+    
+    public void readNBT(NBTTagCompound nbt) {
+    	this.x = nbt.getInteger("b_x");
+    	this.y = nbt.getInteger("b_y");
+    	this.z = nbt.getInteger("b_z");
+    }
+    
+    public void writeNBT(NBTTagCompound nbt) {
+    	nbt.setInteger("b_x",x);
+    	nbt.setInteger("b_y",y);
+    	nbt.setInteger("b_z",z);
+    }
+    
+}

--- a/src/api/java/thaumcraft/api/IArchitect.java
+++ b/src/api/java/thaumcraft/api/IArchitect.java
@@ -1,0 +1,27 @@
+package thaumcraft.api;
+
+import java.util.ArrayList;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IArchitect {
+
+	/**
+	 * Returns a list of blocks that should be highlighted in world.
+	 */
+	public ArrayList<BlockCoordinates> getArchitectBlocks(ItemStack stack, World world, 
+			int x, int y, int z, int side, EntityPlayer player);
+	
+	/**
+	 * which axis should be displayed. 
+	 */
+	public boolean showAxis(ItemStack stack, World world, EntityPlayer player, int side, EnumAxis axis);
+	
+	public enum EnumAxis {
+		X, // east / west
+		Y, // up / down
+		Z; // north / south
+	}
+}

--- a/src/api/java/thaumcraft/api/IGoggles.java
+++ b/src/api/java/thaumcraft/api/IGoggles.java
@@ -1,0 +1,22 @@
+package thaumcraft.api;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Equipped head slot items that extend this class will be able to perform most functions that 
+ * goggles of revealing can apart from view nodes which is handled by IRevealer.
+ *
+ */
+
+public interface IGoggles {
+	
+	/*
+	 * If this method returns true things like block essentia contents will be shown.
+	 */
+	public boolean showIngamePopups(ItemStack itemstack, EntityLivingBase player);
+
+}

--- a/src/api/java/thaumcraft/api/IRepairable.java
+++ b/src/api/java/thaumcraft/api/IRepairable.java
@@ -1,0 +1,13 @@
+package thaumcraft.api;
+
+
+
+/**
+ * @author Azanor
+ * Items, armor and tools with this interface can receive the Repair enchantment. 
+ * Repairs 1 point of durability every 10 seconds (2 for repair II)
+ */
+public interface IRepairable {
+	
+
+}

--- a/src/api/java/thaumcraft/api/IRepairableExtended.java
+++ b/src/api/java/thaumcraft/api/IRepairableExtended.java
@@ -1,0 +1,17 @@
+package thaumcraft.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+
+
+/**
+ * @author Azanor
+ * Items, armor and tools with this interface can receive the Repair enchantment. 
+ * Repairs 1 point of durability every 10 seconds (2 for repair II)
+ */
+public interface IRepairableExtended extends IRepairable {
+	
+	public boolean doRepair(ItemStack stack, EntityPlayer player, int enchantlevel);
+
+}

--- a/src/api/java/thaumcraft/api/IRunicArmor.java
+++ b/src/api/java/thaumcraft/api/IRunicArmor.java
@@ -1,0 +1,22 @@
+package thaumcraft.api;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Armor or bauble slot items that implement this interface can provide runic shielding.
+ * Recharging, hardening, etc. is handled internally by thaumcraft. 
+ *
+ */
+
+public interface IRunicArmor {
+	
+	/**
+	 * returns how much charge this item can provide. This is the base shielding value - any hardening is stored and calculated internally. 
+	 */
+	public int getRunicCharge(ItemStack itemstack);
+	
+
+}

--- a/src/api/java/thaumcraft/api/IScribeTools.java
+++ b/src/api/java/thaumcraft/api/IScribeTools.java
@@ -1,0 +1,14 @@
+package thaumcraft.api;
+
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Interface used to identify scribing tool items used in research table
+ *
+ */
+
+public interface IScribeTools {
+	
+}

--- a/src/api/java/thaumcraft/api/IVisDiscountGear.java
+++ b/src/api/java/thaumcraft/api/IVisDiscountGear.java
@@ -1,0 +1,20 @@
+package thaumcraft.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import thaumcraft.api.aspects.Aspect;
+
+
+
+
+/**
+ * @author Azanor
+ * ItemArmor with this interface will grant a discount to the vis cost of actions the wearer performs with casting wands.
+ * The amount returned is the percentage by which the cost is discounted. There is a built-int max discount of 50%, but 
+ * individual items really shouldn't have a discount more than 5%
+ */
+public interface IVisDiscountGear {
+		
+	int getVisDiscount(ItemStack stack, EntityPlayer player, Aspect aspect);
+
+}

--- a/src/api/java/thaumcraft/api/IWarpingGear.java
+++ b/src/api/java/thaumcraft/api/IWarpingGear.java
@@ -1,0 +1,22 @@
+package thaumcraft.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Armor, held items or bauble slot items that implement this interface add warp when equipped or held.
+ *
+ */
+
+public interface IWarpingGear {
+	
+	/**
+	 * returns how much warp this item adds while worn or held. 
+	 */
+	public int getWarp(ItemStack itemstack, EntityPlayer player);
+	
+
+}

--- a/src/api/java/thaumcraft/api/ItemApi.java
+++ b/src/api/java/thaumcraft/api/ItemApi.java
@@ -1,0 +1,70 @@
+package thaumcraft.api;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.FMLLog;
+
+/**
+ * @author Azanor	
+ * 
+ * This is used to gain access to the items in my mod. 
+ * I only give some examples and it will probably still 
+ * require a bit of work for you to get hold of everything you need.
+ *
+ */
+public class ItemApi {
+	
+	public static ItemStack getItem(String itemString, int meta) {
+		ItemStack item = null;
+
+		try {
+			String itemClass = "thaumcraft.common.config.ConfigItems";
+			Object obj = Class.forName(itemClass).getField(itemString).get(null);
+			if (obj instanceof Item) {
+				item = new ItemStack((Item) obj,1,meta);
+			} else if (obj instanceof ItemStack) {
+				item = (ItemStack) obj;
+			}
+		} catch (Exception ex) {
+			FMLLog.warning("[Thaumcraft] Could not retrieve item identified by: " + itemString);
+		}
+
+		return item;
+	}
+	
+	public static ItemStack getBlock(String itemString, int meta) {
+		ItemStack item = null;
+
+		try {
+			String itemClass = "thaumcraft.common.config.ConfigBlocks";
+			Object obj = Class.forName(itemClass).getField(itemString).get(null);
+			if (obj instanceof Block) {
+				item = new ItemStack((Block) obj,1,meta);
+			} else if (obj instanceof ItemStack) {
+				item = (ItemStack) obj;
+			}
+		} catch (Exception ex) {
+			FMLLog.warning("[Thaumcraft] Could not retrieve block identified by: " + itemString);
+		}
+
+		return item;
+	}
+
+	/** 
+	 * 
+	 * Some examples
+	 * 
+	 * Casting Wands:
+	 * itemWandCasting
+	 *  
+	 * Resources:
+	 * itemEssence, itemWispEssence, itemResource, itemShard, itemNugget, 
+	 * itemNuggetChicken, itemNuggetBeef, itemNuggetPork, itemTripleMeatTreat
+	 * 
+	 * Research:
+	 * itemResearchNotes, itemInkwell, itemThaumonomicon
+	 * 
+	 */
+
+}

--- a/src/api/java/thaumcraft/api/ItemRunic.java
+++ b/src/api/java/thaumcraft/api/ItemRunic.java
@@ -1,0 +1,21 @@
+package thaumcraft.api;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class ItemRunic extends Item implements IRunicArmor  {
+	
+	int charge;
+	
+	public ItemRunic (int charge)
+    {
+        super();
+        this.charge = charge;
+    }
+			
+	@Override
+	public int getRunicCharge(ItemStack itemstack) {
+		return charge;
+	}
+	
+}

--- a/src/api/java/thaumcraft/api/LICENSE
+++ b/src/api/java/thaumcraft/api/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Azanor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this API software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/api/java/thaumcraft/api/README.md
+++ b/src/api/java/thaumcraft/api/README.md
@@ -1,0 +1,10 @@
+thaumcraft-api
+==============
+
+Thaumcraft Api
+
+
+
+This is just to create an easy to access place for the api code. 
+
+I will still place the zips on the minecraft forum post for the "official" version of the api - the code here will usually be for dev versions.

--- a/src/api/java/thaumcraft/api/ThaumcraftApi.java
+++ b/src/api/java/thaumcraft/api/ThaumcraftApi.java
@@ -1,0 +1,588 @@
+package thaumcraft.api;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.Item.ToolMaterial;
+import net.minecraft.item.ItemArmor.ArmorMaterial;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.InfusionEnchantmentRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
+import thaumcraft.api.crafting.ShapelessArcaneRecipe;
+import thaumcraft.api.internal.DummyInternalMethodHandler;
+import thaumcraft.api.internal.IInternalMethodHandler;
+import thaumcraft.api.internal.WeightedRandomLoot;
+import thaumcraft.api.research.IScanEventHandler;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchCategoryList;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
+
+
+/**
+ * @author Azanor
+ *
+ *
+ * IMPORTANT: If you are adding your own aspects to items it is a good idea to do it AFTER Thaumcraft adds its aspects, otherwise odd things may happen.
+ *
+ */
+public class ThaumcraftApi {
+	
+	//Materials	
+	public static ToolMaterial toolMatThaumium = EnumHelper.addToolMaterial("THAUMIUM", 3, 400, 7F, 2, 22);
+	public static ToolMaterial toolMatVoid = EnumHelper.addToolMaterial("VOID", 4, 150, 8F, 3, 10);
+	public static ToolMaterial toolMatElemental = EnumHelper.addToolMaterial("THAUMIUM_ELEMENTAL", 3, 1500, 10F, 3, 18);
+	public static ArmorMaterial armorMatThaumium = EnumHelper.addArmorMaterial("THAUMIUM", 25, new int[] { 2, 6, 5, 2 }, 25);
+	public static ArmorMaterial armorMatSpecial = EnumHelper.addArmorMaterial("SPECIAL", 25, new int[] { 1, 3, 2, 1 }, 25);
+	public static ArmorMaterial armorMatThaumiumFortress = EnumHelper.addArmorMaterial("FORTRESS", 40, new int[] { 3, 7, 6, 3 }, 25);
+	public static ArmorMaterial armorMatVoid = EnumHelper.addArmorMaterial("VOID", 10, new int[] { 3, 7, 6, 3 }, 10);
+	public static ArmorMaterial armorMatVoidFortress = EnumHelper.addArmorMaterial("VOIDFORTRESS", 18, new int[] { 4, 8, 7, 4 }, 10);
+	
+	//Enchantment references
+	public static int enchantFrugal;
+	public static int enchantPotency;
+	public static int enchantWandFortune;
+	public static int enchantHaste;
+	public static int enchantRepair;
+	
+	//Miscellaneous
+	/**
+	 * Portable Hole Block-id Blacklist. 
+	 * Simply add the block-id's of blocks you don't want the portable hole to go through.
+	 */
+	public static ArrayList<Block> portableHoleBlackList = new ArrayList<Block>();
+	
+	//Internal (Do not alter this unless you like pretty explosions)
+	//Calling methods from this will only work properly once Thaumcraft is past the FMLPreInitializationEvent phase.
+	public static IInternalMethodHandler internalMethods = new DummyInternalMethodHandler();	
+	
+	//RESEARCH/////////////////////////////////////////
+	public static ArrayList<IScanEventHandler> scanEventhandlers = new ArrayList<IScanEventHandler>();
+	public static ArrayList<EntityTags> scanEntities = new ArrayList<EntityTags>();
+	public static class EntityTagsNBT {
+		public EntityTagsNBT(String name, Object value) {
+			this.name = name;
+			this.value = value;
+		}
+		public String name;
+		public Object value;
+	}
+	public static class EntityTags {
+		public EntityTags(String entityName, AspectList aspects, EntityTagsNBT... nbts) {
+			this.entityName = entityName;
+			this.nbts = nbts;
+			this.aspects = aspects;
+		}
+		public String entityName;
+		public EntityTagsNBT[] nbts;
+		public AspectList aspects;
+	}
+	
+	/**
+	 * not really working atm, so ignore it for now
+	 * @param scanEventHandler
+	 */
+	public static void registerScanEventhandler(IScanEventHandler scanEventHandler) {
+		scanEventhandlers.add(scanEventHandler);
+	}
+	
+	/**
+	 * This is used to add aspects to entities which you can then scan using a thaumometer.
+	 * Also used to calculate vis drops from mobs.
+	 * @param entityName
+	 * @param aspects
+	 * @param nbt you can specify certain nbt keys and their values 
+	 * 			  to differentiate between mobs. <br>For example the normal and wither skeleton:
+	 * 	<br>ThaumcraftApi.registerEntityTag("Skeleton", (new AspectList()).add(Aspect.DEATH, 5));
+	 * 	<br>ThaumcraftApi.registerEntityTag("Skeleton", (new AspectList()).add(Aspect.DEATH, 8), new NBTTagByte("SkeletonType",(byte) 1));
+	 */
+	public static void registerEntityTag(String entityName, AspectList aspects, EntityTagsNBT... nbt ) {
+		scanEntities.add(new EntityTags(entityName,aspects,nbt));
+	}
+	
+	//RECIPES/////////////////////////////////////////
+	private static ArrayList craftingRecipes = new ArrayList();	
+	private static HashMap<Object,ItemStack> smeltingBonus = new HashMap<Object,ItemStack>();
+	
+	/**
+	 * This method is used to determine what bonus items are generated when the infernal furnace smelts items
+	 * @param in The input of the smelting operation. e.g. new ItemStack(Block.oreGold)
+	 * @param out The bonus item that can be produced from the smelting operation e.g. new ItemStack(nuggetGold,0,0).
+	 * Stacksize should be 0 unless you want to guarantee that at least 1 item is always produced.
+	 */
+	public static void addSmeltingBonus(ItemStack in, ItemStack out) {
+		smeltingBonus.put(
+				Arrays.asList(in.getItem(),in.getItemDamage()), 
+				new ItemStack(out.getItem(),0,out.getItemDamage()));
+	}
+	
+	/**
+	 * This method is used to determine what bonus items are generated when the infernal furnace smelts items
+	 * @param in The ore dictionary input of the smelting operation. e.g. "oreGold"
+	 * @param out The bonus item that can be produced from the smelting operation e.g. new ItemStack(nuggetGold,0,0).
+	 * Stacksize should be 0 unless you want to guarantee that at least 1 item is always produced.
+	 */
+	public static void addSmeltingBonus(String in, ItemStack out) {
+		smeltingBonus.put(	in, new ItemStack(out.getItem(),0,out.getItemDamage()));
+	}
+	
+	/**
+	 * Returns the bonus item produced from a smelting operation in the infernal furnace
+	 * @param in The input of the smelting operation. e.g. new ItemStack(oreGold)
+	 * @return the The bonus item that can be produced
+	 */
+	public static ItemStack getSmeltingBonus(ItemStack in) {
+		ItemStack out = smeltingBonus.get(Arrays.asList(in.getItem(),in.getItemDamage()));
+		if (out==null) {
+			out = smeltingBonus.get(Arrays.asList(in.getItem(),OreDictionary.WILDCARD_VALUE));
+		}
+		if (out==null) {
+			String od = OreDictionary.getOreName( OreDictionary.getOreID(in));
+			out = smeltingBonus.get(od);
+		}
+		return out;
+	}
+	
+	public static List getCraftingRecipes() {
+		return craftingRecipes;
+	}
+	
+	/**
+	 * @param research the research key required for this recipe to work. Leave blank if it will work without research
+	 * @param result the recipe output
+	 * @param aspects the vis cost per aspect. 
+	 * @param recipe The recipe. Format is exactly the same as vanilla recipes. Input itemstacks are NBT sensitive.
+	 */
+	public static ShapedArcaneRecipe addArcaneCraftingRecipe(String research, ItemStack result, AspectList aspects, Object ... recipe)
+    {
+		ShapedArcaneRecipe r= new ShapedArcaneRecipe(research, result, aspects, recipe);
+        craftingRecipes.add(r);
+		return r;
+    }
+	
+	/**
+	 * @param research the research key required for this recipe to work. Leave blank if it will work without research
+	 * @param result the recipe output
+	 * @param aspects the vis cost per aspect
+	 * @param recipe The recipe. Format is exactly the same as vanilla shapeless recipes. Input itemstacks are NBT sensitive.
+	 */
+	public static ShapelessArcaneRecipe addShapelessArcaneCraftingRecipe(String research, ItemStack result, AspectList aspects, Object ... recipe)
+    {
+		ShapelessArcaneRecipe r = new ShapelessArcaneRecipe(research, result, aspects, recipe);
+        craftingRecipes.add(r);
+		return r;
+    }
+	
+	/**
+	 * @param research the research key required for this recipe to work. Leave blank if it will work without research
+	 * @param result the recipe output. It can either be an itemstack or an nbt compound tag that will be added to the central item
+	 * @param instability a number that represents the N in 1000 chance for the infusion altar to spawn an
+	 * 		  instability effect each second while the crafting is in progress
+	 * @param aspects the essentia cost per aspect. 
+	 * @param aspects input the central item to be infused
+	 * @param recipe An array of items required to craft this. Input itemstacks are NBT sensitive. 
+	 * 				Infusion crafting components are automatically "fuzzy" and the oredict will be checked for possible matches.
+	 * 
+	 */
+	public static InfusionRecipe addInfusionCraftingRecipe(String research, Object result, int instability, AspectList aspects, ItemStack input,ItemStack[] recipe)
+    {
+		if (!(result instanceof ItemStack || result instanceof Object[])) return null;
+		InfusionRecipe r= new InfusionRecipe(research, result, instability, aspects, input, recipe);
+        craftingRecipes.add(r);
+		return r;
+    }
+	
+	/**
+	 * @param research the research key required for this recipe to work. Leave blank if it will work without research
+	 * @param enchantment the enchantment that will be applied to the item
+	 * @param instability a number that represents the N in 1000 chance for the infusion altar to spawn an
+	 * 		  instability effect each second while the crafting is in progress
+	 * @param aspects the essentia cost per aspect. 
+	 * @param recipe An array of items required to craft this. Input itemstacks are NBT sensitive. 
+	 * 				Infusion crafting components are automatically "fuzzy" and the oredict will be checked for possible matches.
+	 * 
+	 */
+	public static InfusionEnchantmentRecipe addInfusionEnchantmentRecipe(String research, Enchantment enchantment, int instability, AspectList aspects, ItemStack[] recipe)
+    {
+		InfusionEnchantmentRecipe r= new InfusionEnchantmentRecipe(research, enchantment, instability, aspects, recipe);
+        craftingRecipes.add(r);
+		return r;
+    }
+	
+	/**
+	 * @param stack the recipe result
+	 * @return the recipe
+	 */
+	public static InfusionRecipe getInfusionRecipe(ItemStack res) {
+		for (Object r:getCraftingRecipes()) {
+			if (r instanceof InfusionRecipe) {
+				if (((InfusionRecipe)r).getRecipeOutput() instanceof ItemStack) {
+					if (((ItemStack) ((InfusionRecipe)r).getRecipeOutput()).isItemEqual(res))
+						return (InfusionRecipe)r;
+				} 
+			}
+		}
+		return null;
+	}
+
+    
+    /**
+     * @param key the research key required for this recipe to work. 
+     * @param result the output result
+     * @param catalyst an itemstack of the catalyst or a string if it is an ore dictionary item
+     * @param cost the vis cost
+     * @param tags the aspects required to craft this
+     */
+    public static CrucibleRecipe addCrucibleRecipe(String key, ItemStack result, Object catalyst, AspectList tags) {
+    	CrucibleRecipe rc = new CrucibleRecipe(key, result, catalyst, tags);
+    	getCraftingRecipes().add(rc);
+		return rc;
+	}
+    
+	
+	/**
+	 * @param stack the recipe result
+	 * @return the recipe
+	 */
+	public static CrucibleRecipe getCrucibleRecipe(ItemStack stack) {
+		for (Object r:getCraftingRecipes()) {
+			if (r instanceof CrucibleRecipe) {
+				if (((CrucibleRecipe)r).getRecipeOutput().isItemEqual(stack))
+					return (CrucibleRecipe)r;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * @param hash the unique recipe code
+	 * @return the recipe
+	 */
+	public static CrucibleRecipe getCrucibleRecipeFromHash(int hash) {
+		for (Object r:getCraftingRecipes()) {
+			if (r instanceof CrucibleRecipe) {
+				if (((CrucibleRecipe)r).hash==hash)
+					return (CrucibleRecipe)r;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Used by the thaumonomicon drilldown feature.
+	 * @param stack the item
+	 * @return the thaumcraft recipe key that produces that item. 
+	 */
+	private static HashMap<int[],Object[]> keyCache = new HashMap<int[],Object[]>();
+	
+	public static Object[] getCraftingRecipeKey(EntityPlayer player, ItemStack stack) {
+		int[] key = new int[] {Item.getIdFromItem(stack.getItem()),stack.getItemDamage()};
+		if (keyCache.containsKey(key)) {
+			if (keyCache.get(key)==null) return null;
+			if (ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), (String)(keyCache.get(key))[0]))
+				return keyCache.get(key);
+			else 
+				return null;
+		}
+		for (ResearchCategoryList rcl:ResearchCategories.researchCategories.values()) {
+			for (ResearchItem ri:rcl.research.values()) {
+				if (ri.getPages()==null) continue;
+				for (int a=0;a<ri.getPages().length;a++) {
+					ResearchPage page = ri.getPages()[a];
+					if (page.recipe!=null && page.recipe instanceof CrucibleRecipe[]) {
+						CrucibleRecipe[] crs = (CrucibleRecipe[]) page.recipe;
+						for (CrucibleRecipe cr:crs) {
+							if (cr.getRecipeOutput().isItemEqual(stack)) {
+								keyCache.put(key,new Object[] {ri.key,a});
+								if (ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), ri.key))
+									return new Object[] {ri.key,a};
+							}
+						}
+					} else
+					if (page.recipeOutput!=null && stack !=null && page.recipeOutput.isItemEqual(stack)) {
+						keyCache.put(key,new Object[] {ri.key,a});
+						if (ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), ri.key))
+							return new Object[] {ri.key,a};
+						else 
+							return null;
+					}
+				}
+			}
+		}
+		keyCache.put(key,null);
+		return null;
+	}
+	
+	//ASPECTS////////////////////////////////////////
+	
+	public static ConcurrentHashMap<List,AspectList> objectTags = new ConcurrentHashMap<List,AspectList>();
+	public static ConcurrentHashMap<List,int[]> groupedObjectTags = new ConcurrentHashMap<List,int[]>();
+	
+	/**
+	 * Checks to see if the passed item/block already has aspects associated with it.
+	 * @param id
+	 * @param meta
+	 * @return 
+	 */
+	public static boolean exists(Item item, int meta) {
+		AspectList tmp = ThaumcraftApi.objectTags.get(Arrays.asList(item,meta));
+		if (tmp==null) {
+			tmp = ThaumcraftApi.objectTags.get(Arrays.asList(item,OreDictionary.WILDCARD_VALUE));
+			if (meta==OreDictionary.WILDCARD_VALUE && tmp==null) {
+				int index=0;
+				do {
+					tmp = ThaumcraftApi.objectTags.get(Arrays.asList(item,index));
+					index++;
+				} while (index<16 && tmp==null);
+			}
+			if (tmp==null) return false;
+		}
+		
+		return true;
+	}
+	
+	/**
+	 * Used to assign apsects to the given item/block. Here is an example of the declaration for cobblestone:<p>
+	 * <i>ThaumcraftApi.registerObjectTag(new ItemStack(Blocks.cobblestone), (new AspectList()).add(Aspect.ENTROPY, 1).add(Aspect.EARTH, 1));</i>
+	 * @param item the item passed. Pass OreDictionary.WILDCARD_VALUE if all damage values of this item/block should have the same aspects
+	 * @param aspects A ObjectTags object of the associated aspects
+	 */
+	public static void registerObjectTag(ItemStack item, AspectList aspects) {
+		if (aspects==null) aspects=new AspectList();
+		try {
+		objectTags.put(Arrays.asList(item.getItem(),item.getItemDamage()), aspects);
+		} catch (Exception e) {}
+	}	
+	
+	
+	/**
+	 * Used to assign apsects to the given item/block. Here is an example of the declaration for cobblestone:<p>
+	 * <i>ThaumcraftApi.registerObjectTag(new ItemStack(Blocks.cobblestone), new int[]{0,1}, (new AspectList()).add(Aspect.ENTROPY, 1).add(Aspect.EARTH, 1));</i>
+	 * @param item
+	 * @param meta A range of meta values if you wish to lump several item meta's together as being the "same" item (i.e. stair orientations)
+	 * @param aspects A ObjectTags object of the associated aspects
+	 */
+	public static void registerObjectTag(ItemStack item, int[] meta, AspectList aspects) {
+		if (aspects==null) aspects=new AspectList();
+		try {			
+			objectTags.put(Arrays.asList(item.getItem(),meta[0]), aspects);
+			for (int m:meta) {				
+				groupedObjectTags.put(Arrays.asList(item.getItem(),m), meta);
+			}
+			
+		} catch (Exception e) {}
+	}
+	
+	/**
+	 * Used to assign apsects to the given ore dictionary item. 
+	 * @param oreDict the ore dictionary name
+	 * @param aspects A ObjectTags object of the associated aspects
+	 */
+	public static void registerObjectTag(String oreDict, AspectList aspects) {
+		if (aspects==null) aspects=new AspectList();
+		ArrayList<ItemStack> ores = OreDictionary.getOres(oreDict);
+		if (ores!=null && ores.size()>0) {
+			for (ItemStack ore:ores) {
+				try {
+				objectTags.put(Arrays.asList(ore.getItem(), ore.getItemDamage()), aspects);
+				} catch (Exception e) {}
+			}
+		}
+	}
+	
+	/**
+	 * Used to assign aspects to the given item/block. 
+	 * Attempts to automatically generate aspect tags by checking registered recipes.
+	 * Here is an example of the declaration for pistons:<p>
+	 * <i>ThaumcraftApi.registerComplexObjectTag(new ItemStack(Blocks.cobblestone), (new AspectList()).add(Aspect.MECHANISM, 2).add(Aspect.MOTION, 4));</i>
+	 * IMPORTANT - this should only be used if you are not happy with the default aspects the object would be assigned.
+	 * @param item, pass OreDictionary.WILDCARD_VALUE to meta if all damage values of this item/block should have the same aspects
+	 * @param aspects A ObjectTags object of the associated aspects
+	 */
+	public static void registerComplexObjectTag(ItemStack item, AspectList aspects ) {
+		if (!exists(item.getItem(),item.getItemDamage())) {
+			AspectList tmp = ThaumcraftApiHelper.generateTags(item.getItem(), item.getItemDamage());
+			if (tmp != null && tmp.size()>0) {
+				for(Aspect tag:tmp.getAspects()) {
+					aspects.add(tag, tmp.getAmount(tag));
+				}
+			}
+			registerObjectTag(item,aspects);
+		} else {
+			AspectList tmp = ThaumcraftApiHelper.getObjectAspects(item);
+			for(Aspect tag:aspects.getAspects()) {
+				tmp.merge(tag, tmp.getAmount(tag));
+			}
+			registerObjectTag(item,tmp);
+		}
+	}
+	
+	//WARP ///////////////////////////////////////////////////////////////////////////////////////
+		private static HashMap<Object,Integer> warpMap = new HashMap<Object,Integer>();
+		
+		/**
+		 * This method is used to determine how much warp is gained if the item is crafted. The warp
+		 * added is "sticky" warp
+		 * @param craftresult The item crafted
+		 * @param amount how much warp is gained
+		 */
+		public static void addWarpToItem(ItemStack craftresult, int amount) {
+			warpMap.put(Arrays.asList(craftresult.getItem(),craftresult.getItemDamage()),amount);
+		}
+		
+		/**
+		 * This method is used to determine how much permanent warp is gained if the research is completed
+		 * @param in The item crafted
+		 * @param amount how much warp is gained
+		 */
+		public static void addWarpToResearch(String research, int amount) {
+			warpMap.put(research, amount);
+		}
+		
+		/**
+		 * Returns how much warp is gained from the item or research passed in
+		 * @param in itemstack or string
+		 * @return how much warp it will give
+		 */
+		public static int getWarp(Object in) {
+			if (in==null) return 0;
+			if (in instanceof ItemStack && warpMap.containsKey(Arrays.asList(((ItemStack)in).getItem(),((ItemStack)in).getItemDamage()))) {
+				return warpMap.get(Arrays.asList(((ItemStack)in).getItem(),((ItemStack)in).getItemDamage()));
+			} else
+			if (in instanceof String && warpMap.containsKey((String)in)) {
+				return warpMap.get((String)in);
+			}
+			return 0;
+		}
+	
+	//LOOT BAGS //////////////////////////////////////////////////////////////////////////////////////////
+		
+		/**
+		 * Used to add possible loot to treasure bags. As a reference, the weight of gold coins are 2000 
+		 * and a diamond is 50.
+		 * The weights are the same for all loot bag types - the only difference is how many items the bag
+		 * contains.
+		 * @param item
+		 * @param weight
+		 * @param bagTypes array of which type of bag to add this loot to. Multiple types can be specified
+		 * 0 = common, 1 = uncommon, 2 = rare
+		 */
+		public static void addLootBagItem(ItemStack item, int weight, int... bagTypes) {
+			if (bagTypes==null || bagTypes.length==0)
+				WeightedRandomLoot.lootBagCommon.add(new WeightedRandomLoot(item,weight));
+			else {
+				for (int rarity:bagTypes) {
+					switch(rarity) {
+						case 0: WeightedRandomLoot.lootBagCommon.add(new WeightedRandomLoot(item,weight)); break;
+						case 1: WeightedRandomLoot.lootBagUncommon.add(new WeightedRandomLoot(item,weight)); break;
+						case 2: WeightedRandomLoot.lootBagRare.add(new WeightedRandomLoot(item,weight)); break;
+					}
+				}
+			}
+		}
+		
+	//CROPS //////////////////////////////////////////////////////////////////////////////////////////
+	
+	/**
+	 * To define mod crops you need to use FMLInterModComms in your @Mod.Init method.
+	 * There are two 'types' of crops you can add. Standard crops and clickable crops.
+	 * 
+	 * Standard crops work like normal vanilla crops - they grow until a certain metadata 
+	 * value is reached and you harvest them by destroying the block and collecting the blocks.
+	 * You need to create and ItemStack that tells the golem what block id and metadata represents
+	 * the crop when fully grown. Sending a metadata of [OreDictionary.WILDCARD_VALUE] will mean the metadata won't get 
+	 * checked.
+	 * Example for vanilla wheat: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "harvestStandardCrop", new ItemStack(Block.crops,1,7));
+	 *  
+	 * Clickable crops are crops that you right click to gather their bounty instead of destroying them.
+	 * As for standard crops, you need to create and ItemStack that tells the golem what block id 
+	 * and metadata represents the crop when fully grown. The golem will trigger the blocks onBlockActivated method. 
+	 * Sending a metadata of [OreDictionary.WILDCARD_VALUE] will mean the metadata won't get checked.
+	 * Example (this will technically do nothing since clicking wheat does nothing, but you get the idea): 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "harvestClickableCrop", new ItemStack(Block.crops,1,7));
+	 * 
+	 * Stacked crops (like reeds) are crops that you wish the bottom block should remain after harvesting.
+	 * As for standard crops, you need to create and ItemStack that tells the golem what block id 
+	 * and metadata represents the crop when fully grown. Sending a metadata of [OreDictionary.WILDCARD_VALUE] will mean the actualy md won't get 
+	 * checked. If it has the order upgrade it will only harvest if the crop is more than one block high.
+	 * Example: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "harvestStackedCrop", new ItemStack(Block.reed,1,7));
+	 */
+	
+	//NATIVE CLUSTERS //////////////////////////////////////////////////////////////////////////////////
+	
+	/**
+	 * You can define certain ores that will have a chance to produce native clusters via FMLInterModComms 
+	 * in your @Mod.Init method using the "nativeCluster" string message.
+	 * The format should be: 
+	 * "[ore item/block id],[ore item/block metadata],[cluster item/block id],[cluster item/block metadata],[chance modifier float]"
+	 * 
+	 * NOTE: The chance modifier is a multiplier applied to the default chance for that cluster to be produced (default 27.5% for a pickaxe of the core)
+	 * 
+	 * Example for vanilla iron ore to produce one of my own native iron clusters (assuming default id's) at double the default chance: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "nativeCluster","15,0,25016,16,2.0");
+	 */
+	
+	//LAMP OF GROWTH BLACKLIST ///////////////////////////////////////////////////////////////////////////
+	/**
+	 * You can blacklist crops that should not be effected by the Lamp of Growth via FMLInterModComms 
+	 * in your @Mod.Init method using the "lampBlacklist" itemstack message.
+	 * Sending a metadata of [OreDictionary.WILDCARD_VALUE] will mean the metadata won't get checked.
+	 * Example for vanilla wheat: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "lampBlacklist", new ItemStack(Block.crops,1,OreDictionary.WILDCARD_VALUE));
+	 */
+	
+	//DIMENSION BLACKLIST ///////////////////////////////////////////////////////////////////////////
+	/**
+	 * You can blacklist a dimension to not spawn certain thaumcraft features 
+	 * in your @Mod.Init method using the "dimensionBlacklist" string message in the format "[dimension]:[level]"
+	 * The level values are as follows:
+	 * [0] stop all tc spawning and generation
+	 * [1] allow ore and node generation (and node special features)
+	 * [2] allow mob spawning
+	 * [3] allow ore and node gen + mob spawning (and node special features)
+	 * Example: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "dimensionBlacklist", "15:1");
+	 */
+	
+	//BIOME BLACKLIST ///////////////////////////////////////////////////////////////////////////
+	/**
+	 * You can blacklist a biome to not spawn certain thaumcraft features 
+	 * in your @Mod.Init method using the "biomeBlacklist" string message in the format "[biome id]:[level]"
+	 * The level values are as follows:
+	 * [0] stop all tc spawning and generation
+	 * [1] allow ore and node generation (and node special features)
+	 * [2] allow mob spawning
+	 * [3] allow ore and node gen + mob spawning (and node special features)
+	 * Example: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "biomeBlacklist", "180:2");
+	 */
+		
+	//CHAMPION MOB WHITELIST ///////////////////////////////////////////////////////////////////////////
+	/**
+	 * You can whitelist an entity class so it can rarely spawn champion versions in your @Mod.Init method using 
+	 * the "championWhiteList" string message in the format "[Entity]:[level]"
+	 * The entity must extend EntityMob.
+	 * [Entity] is in a similar format to what is used for mob spawners and such (see EntityList.class for vanilla examples).
+	 * The [level] value indicate how rare the champion version will be - the higher the number the more common. 
+	 * The number roughly equals the [n] in 100 chance of a mob being a champion version. 
+	 * You can give 0 or negative numbers to allow champions to spawn with a very low chance only in particularly dangerous places. 
+	 * However anything less than about -2 will probably result in no spawns at all.
+	 * Example: 
+	 * FMLInterModComms.sendMessage("Thaumcraft", "championWhiteList", "Thaumcraft.Wisp:1");
+	 */
+}

--- a/src/api/java/thaumcraft/api/ThaumcraftApiHelper.java
+++ b/src/api/java/thaumcraft/api/ThaumcraftApiHelper.java
@@ -1,0 +1,467 @@
+package thaumcraft.api;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.IEssentiaTransport;
+
+public class ThaumcraftApiHelper {
+	
+	public static AspectList cullTags(AspectList temp) {
+		AspectList temp2 = new AspectList();
+		for (Aspect tag:temp.getAspects()) {
+			if (tag!=null)
+				temp2.add(tag, temp.getAmount(tag));
+		}
+		while (temp2!=null && temp2.size()>6) {
+			Aspect lowest = null;
+			float low = Short.MAX_VALUE;
+			for (Aspect tag:temp2.getAspects()) {
+				if (tag==null) continue;
+				float ta=temp2.getAmount(tag);
+				if (tag.isPrimal()) {
+					ta *= .9f;
+				} else {
+					if (!tag.getComponents()[0].isPrimal()) {
+						ta *= 1.1f;
+						if (!tag.getComponents()[0].getComponents()[0].isPrimal()) {
+							ta *= 1.05f;
+						}
+						if (!tag.getComponents()[0].getComponents()[1].isPrimal()) {
+							ta *= 1.05f;
+						}
+					}
+					if (!tag.getComponents()[1].isPrimal()) {
+						ta *= 1.1f;
+						if (!tag.getComponents()[1].getComponents()[0].isPrimal()) {
+							ta *= 1.05f;
+						}
+						if (!tag.getComponents()[1].getComponents()[1].isPrimal()) {
+							ta *= 1.05f;
+						}
+					}
+				}
+				
+				if (ta<low) {
+					low = ta;					 
+					lowest = tag;
+				}
+			}
+			temp2.aspects.remove(lowest);
+		}
+		return temp2; 
+	}
+	
+	public static boolean areItemsEqual(ItemStack s1,ItemStack s2)
+    {
+		if (s1.isItemStackDamageable() && s2.isItemStackDamageable())
+		{
+			return s1.getItem() == s2.getItem();
+		} else
+			return s1.getItem() == s2.getItem() && s1.getItemDamage() == s2.getItemDamage();
+    }
+
+	public static boolean isResearchComplete(String username, String researchkey) {
+		return ThaumcraftApi.internalMethods.isResearchComplete(username, researchkey);
+	}
+	
+	public static boolean hasDiscoveredAspect(String username, Aspect aspect) {
+		return ThaumcraftApi.internalMethods.hasDiscoveredAspect(username, aspect);
+	}
+	
+	public static AspectList getDiscoveredAspects(String username) {
+		return ThaumcraftApi.internalMethods.getDiscoveredAspects(username);
+	}
+
+	public static ItemStack getStackInRowAndColumn(Object instance, int row, int column) {
+		return ThaumcraftApi.internalMethods.getStackInRowAndColumn(instance, row, column);
+	}
+
+	public static AspectList getObjectAspects(ItemStack is) {
+		return ThaumcraftApi.internalMethods.getObjectAspects(is);
+	}
+
+	public static AspectList getBonusObjectTags(ItemStack is,AspectList ot) {
+		return ThaumcraftApi.internalMethods.getBonusObjectTags(is, ot);
+	}
+
+	public static AspectList generateTags(Item item, int meta) {
+		return ThaumcraftApi.internalMethods.generateTags(item, meta);
+	}
+	
+	public static boolean containsMatch(boolean strict, ItemStack[] inputs, ItemStack... targets)
+    {
+        for (ItemStack input : inputs)
+        {
+            for (ItemStack target : targets)
+            {
+                if (itemMatches(target, input, strict))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+	
+	public static boolean areItemStackTagsEqualForCrafting(ItemStack slotItem,ItemStack recipeItem)
+    {
+    	if (recipeItem == null || slotItem == null) return false;
+    	if (recipeItem.stackTagCompound!=null && slotItem.stackTagCompound==null ) return false;
+    	if (recipeItem.stackTagCompound==null ) return true;
+    	
+    	Iterator iterator = recipeItem.stackTagCompound.func_150296_c().iterator();
+        while (iterator.hasNext())
+        {
+            String s = (String)iterator.next();
+            if (slotItem.stackTagCompound.hasKey(s)) {
+            	if (!slotItem.stackTagCompound.getTag(s).toString().equals(
+            			recipeItem.stackTagCompound.getTag(s).toString())) {
+            		return false;
+            	}
+            } else {
+        		return false;
+            }
+            
+        }
+        return true;
+    }
+
+    public static boolean itemMatches(ItemStack target, ItemStack input, boolean strict)
+    {
+        if (input == null && target != null || input != null && target == null)
+        {
+            return false;
+        }
+        return (target.getItem() == input.getItem() && 
+        		((target.getItemDamage() == OreDictionary.WILDCARD_VALUE && !strict) || target.getItemDamage() == input.getItemDamage()));
+    }
+    
+    
+    public static TileEntity getConnectableTile(World world, int x, int y, int z, ForgeDirection face) {
+		TileEntity te = world.getTileEntity(x+face.offsetX, y+face.offsetY, z+face.offsetZ);
+		if (te instanceof IEssentiaTransport && ((IEssentiaTransport)te).isConnectable(face.getOpposite())) 
+			return te;
+		else
+			return null;
+	}
+    
+    public static TileEntity getConnectableTile(IBlockAccess world, int x, int y, int z, ForgeDirection face) {
+		TileEntity te = world.getTileEntity(x+face.offsetX, y+face.offsetY, z+face.offsetZ);
+		if (te instanceof IEssentiaTransport && ((IEssentiaTransport)te).isConnectable(face.getOpposite())) 
+			return te;
+		else
+			return null;
+	}
+    
+    private static HashMap<Integer, AspectList> allAspects= new HashMap<Integer, AspectList>();
+    private static HashMap<Integer, AspectList> allCompoundAspects= new HashMap<Integer, AspectList>();
+    
+    public static AspectList getAllAspects(int amount) {
+    	if (allAspects.get(amount)==null) {
+    		AspectList al = new AspectList();
+    		for (Aspect aspect:Aspect.aspects.values()) {
+    			al.add(aspect, amount);
+    		}
+    		allAspects.put(amount, al);
+    	} 
+    	return allAspects.get(amount);
+    }
+    
+    public static AspectList getAllCompoundAspects(int amount) {
+    	if (allCompoundAspects.get(amount)==null) {
+    		AspectList al = new AspectList();
+    		for (Aspect aspect:Aspect.getCompoundAspects()) {
+    			al.add(aspect, amount);
+    		}
+    		allCompoundAspects.put(amount, al);
+    	} 
+    	return allCompoundAspects.get(amount);
+    }
+    
+    
+	/**
+	 * Use to subtract vis from a wand for most operations
+	 * Wands store vis differently so "real" vis costs need to be multiplied by 100 before calling this method
+	 * @param wand the wand itemstack
+	 * @param player the player using the wand
+	 * @param cost the cost of the operation. 
+	 * @param doit actually subtract the vis from the wand if true - if false just simulate the result
+	 * @param crafting is this a crafting operation or not - if 
+	 * false then things like frugal and potency will apply to the costs
+	 * @return was the vis successfully subtracted
+	 */
+	public static boolean consumeVisFromWand(ItemStack wand, EntityPlayer player, 
+			AspectList cost, boolean doit, boolean crafting) {
+		return ThaumcraftApi.internalMethods.consumeVisFromWand(wand, player, cost, doit, crafting);
+	}
+	
+	/**
+	 * Subtract vis for use by a crafting mechanic. Costs are calculated slightly 
+	 * differently and things like the frugal enchant is ignored
+	 * Must NOT be multiplied by 100 - send the actual vis cost
+	 * @param wand the wand itemstack
+	 * @param player the player using the wand
+	 * @param cost the cost of the operation. 
+	 * @param doit actually subtract the vis from the wand if true - if false just simulate the result
+	 * @return was the vis successfully subtracted
+	 */
+	public static boolean consumeVisFromWandCrafting(ItemStack wand, EntityPlayer player, 
+			AspectList cost, boolean doit) {
+		return ThaumcraftApi.internalMethods.consumeVisFromWandCrafting(wand, player, cost, doit);
+	}
+	
+	/**
+	 * Subtract vis from a wand the player is carrying. Works like consumeVisFromWand in that actual vis
+	 * costs should be multiplied by 100. The costs are handled like crafting however and things like 
+	 * frugal don't effect them
+	 * @param player the player using the wand
+	 * @param cost the cost of the operation. 
+	 * @return was the vis successfully subtracted
+	 */
+	public static boolean consumeVisFromInventory(EntityPlayer player, AspectList cost) {
+		return ThaumcraftApi.internalMethods.consumeVisFromInventory(player, cost);
+	}
+	
+	
+	/**
+	 * This adds permanents or temporary warp to a player. It will automatically be synced clientside
+	 * @param player the player using the wand
+	 * @param amount how much warp to add. Negative amounts are only valid for temporary warp
+	 * @param temporary add temporary warp instead of permanent
+	 */
+	public static void addWarpToPlayer(EntityPlayer player, int amount, boolean temporary) {
+		ThaumcraftApi.internalMethods.addWarpToPlayer(player, amount, temporary);
+	}
+	
+	/**
+	 * This "sticky" warp to a player. Sticky warp is permanent warp that can be removed.
+	 * It will automatically be synced clientside
+	 * @param player the player using the wand
+	 * @param amount how much warp to add. Can have negative amounts.
+	 */
+	public static void addStickyWarpToPlayer(EntityPlayer player, int amount) {
+		ThaumcraftApi.internalMethods.addStickyWarpToPlayer(player, amount);
+	}
+
+	public static MovingObjectPosition rayTraceIgnoringSource(World world, Vec3 v1, Vec3 v2, 
+			boolean bool1, boolean bool2, boolean bool3)
+	{
+	    if (!Double.isNaN(v1.xCoord) && !Double.isNaN(v1.yCoord) && !Double.isNaN(v1.zCoord))
+	    {
+	        if (!Double.isNaN(v2.xCoord) && !Double.isNaN(v2.yCoord) && !Double.isNaN(v2.zCoord))
+	        {
+	            int i = MathHelper.floor_double(v2.xCoord);
+	            int j = MathHelper.floor_double(v2.yCoord);
+	            int k = MathHelper.floor_double(v2.zCoord);
+	            int l = MathHelper.floor_double(v1.xCoord);
+	            int i1 = MathHelper.floor_double(v1.yCoord);
+	            int j1 = MathHelper.floor_double(v1.zCoord);
+	            Block block = world.getBlock(l, i1, j1);
+	            int k1 = world.getBlockMetadata(l, i1, j1);
+	
+	            MovingObjectPosition movingobjectposition2 = null;
+	            k1 = 200;
+	
+	            while (k1-- >= 0)
+	            {
+	                if (Double.isNaN(v1.xCoord) || Double.isNaN(v1.yCoord) || Double.isNaN(v1.zCoord))
+	                {
+	                    return null;
+	                }
+	
+	                if (l == i && i1 == j && j1 == k)
+	                {
+	                    continue;
+	                }
+	
+	                boolean flag6 = true;
+	                boolean flag3 = true;
+	                boolean flag4 = true;
+	                double d0 = 999.0D;
+	                double d1 = 999.0D;
+	                double d2 = 999.0D;
+	
+	                if (i > l)
+	                {
+	                    d0 = (double)l + 1.0D;
+	                }
+	                else if (i < l)
+	                {
+	                    d0 = (double)l + 0.0D;
+	                }
+	                else
+	                {
+	                    flag6 = false;
+	                }
+	
+	                if (j > i1)
+	                {
+	                    d1 = (double)i1 + 1.0D;
+	                }
+	                else if (j < i1)
+	                {
+	                    d1 = (double)i1 + 0.0D;
+	                }
+	                else
+	                {
+	                    flag3 = false;
+	                }
+	
+	                if (k > j1)
+	                {
+	                    d2 = (double)j1 + 1.0D;
+	                }
+	                else if (k < j1)
+	                {
+	                    d2 = (double)j1 + 0.0D;
+	                }
+	                else
+	                {
+	                    flag4 = false;
+	                }
+	
+	                double d3 = 999.0D;
+	                double d4 = 999.0D;
+	                double d5 = 999.0D;
+	                double d6 = v2.xCoord - v1.xCoord;
+	                double d7 = v2.yCoord - v1.yCoord;
+	                double d8 = v2.zCoord - v1.zCoord;
+	
+	                if (flag6)
+	                {
+	                    d3 = (d0 - v1.xCoord) / d6;
+	                }
+	
+	                if (flag3)
+	                {
+	                    d4 = (d1 - v1.yCoord) / d7;
+	                }
+	
+	                if (flag4)
+	                {
+	                    d5 = (d2 - v1.zCoord) / d8;
+	                }
+	
+	                boolean flag5 = false;
+	                byte b0;
+	
+	                if (d3 < d4 && d3 < d5)
+	                {
+	                    if (i > l)
+	                    {
+	                        b0 = 4;
+	                    }
+	                    else
+	                    {
+	                        b0 = 5;
+	                    }
+	
+	                    v1.xCoord = d0;
+	                    v1.yCoord += d7 * d3;
+	                    v1.zCoord += d8 * d3;
+	                }
+	                else if (d4 < d5)
+	                {
+	                    if (j > i1)
+	                    {
+	                        b0 = 0;
+	                    }
+	                    else
+	                    {
+	                        b0 = 1;
+	                    }
+	
+	                    v1.xCoord += d6 * d4;
+	                    v1.yCoord = d1;
+	                    v1.zCoord += d8 * d4;
+	                }
+	                else
+	                {
+	                    if (k > j1)
+	                    {
+	                        b0 = 2;
+	                    }
+	                    else
+	                    {
+	                        b0 = 3;
+	                    }
+	
+	                    v1.xCoord += d6 * d5;
+	                    v1.yCoord += d7 * d5;
+	                    v1.zCoord = d2;
+	                }
+	
+	                Vec3 vec32 = Vec3.createVectorHelper(v1.xCoord, v1.yCoord, v1.zCoord);
+	                l = (int)(vec32.xCoord = (double)MathHelper.floor_double(v1.xCoord));
+	
+	                if (b0 == 5)
+	                {
+	                    --l;
+	                    ++vec32.xCoord;
+	                }
+	
+	                i1 = (int)(vec32.yCoord = (double)MathHelper.floor_double(v1.yCoord));
+	
+	                if (b0 == 1)
+	                {
+	                    --i1;
+	                    ++vec32.yCoord;
+	                }
+	
+	                j1 = (int)(vec32.zCoord = (double)MathHelper.floor_double(v1.zCoord));
+	
+	                if (b0 == 3)
+	                {
+	                    --j1;
+	                    ++vec32.zCoord;
+	                }
+	
+	                Block block1 = world.getBlock(l, i1, j1);
+	                int l1 = world.getBlockMetadata(l, i1, j1);
+	
+	                if (!bool2 || block1.getCollisionBoundingBoxFromPool(world, l, i1, j1) != null)
+	                {
+	                    if (block1.canCollideCheck(l1, bool1))
+	                    {
+	                        MovingObjectPosition movingobjectposition1 = block1.collisionRayTrace(world, l, i1, j1, v1, v2);
+	
+	                        if (movingobjectposition1 != null)
+	                        {
+	                            return movingobjectposition1;
+	                        }
+	                    }
+	                    else
+	                    {
+	                        movingobjectposition2 = new MovingObjectPosition(l, i1, j1, b0, v1, false);
+	                    }
+	                }
+	            }
+	
+	            return bool3 ? movingobjectposition2 : null;
+	        }
+	        else
+	        {
+	            return null;
+	        }
+	    }
+	    else
+	    {
+	        return null;
+	    }
+	}
+}

--- a/src/api/java/thaumcraft/api/TileThaumcraft.java
+++ b/src/api/java/thaumcraft/api/TileThaumcraft.java
@@ -1,0 +1,63 @@
+package thaumcraft.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * 
+ * @author azanor
+ *
+ * Custom tile entity class I use for most of my tile entities. Setup in such a way that only 
+ * the nbt data within readCustomNBT / writeCustomNBT will be sent to the client when the tile
+ * updates. Apart from all the normal TE data that gets sent that is.
+ * 
+ */
+public class TileThaumcraft extends TileEntity {
+		
+	//NBT stuff
+	
+	@Override
+	public void readFromNBT(NBTTagCompound nbttagcompound)
+    {
+        super.readFromNBT(nbttagcompound);
+        readCustomNBT(nbttagcompound);
+    }
+	
+	public void readCustomNBT(NBTTagCompound nbttagcompound)
+    {
+        //TODO
+    }
+
+	@Override
+    public void writeToNBT(NBTTagCompound nbttagcompound)
+    {
+        super.writeToNBT(nbttagcompound);
+        writeCustomNBT(nbttagcompound);
+    }
+	
+	public void writeCustomNBT(NBTTagCompound nbttagcompound)
+    {
+		//TODO
+    }
+	
+	//Client Packet stuff
+	@Override
+	public Packet getDescriptionPacket() {
+		NBTTagCompound nbttagcompound = new NBTTagCompound();
+        this.writeCustomNBT(nbttagcompound);
+        return new S35PacketUpdateTileEntity(this.xCoord, this.yCoord, this.zCoord, -999, nbttagcompound);
+	}
+
+	@Override
+	public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
+		super.onDataPacket(net, pkt);		
+		this.readCustomNBT(pkt.func_148857_g());
+	}
+	
+	
+	
+
+}

--- a/src/api/java/thaumcraft/api/WorldCoordinates.java
+++ b/src/api/java/thaumcraft/api/WorldCoordinates.java
@@ -1,0 +1,117 @@
+package thaumcraft.api;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+public class WorldCoordinates implements Comparable
+{
+    public int x;
+
+    /** the y coordinate */
+    public int y;
+
+    /** the z coordinate */
+    public int z;
+    
+    public int dim;
+
+    public WorldCoordinates() {}
+
+    public WorldCoordinates(int par1, int par2, int par3, int d)
+    {
+        this.x = par1;
+        this.y = par2;
+        this.z = par3;
+        this.dim = d;
+    }
+    
+    public WorldCoordinates(TileEntity tile)
+    {
+        this.x = tile.xCoord;
+        this.y = tile.yCoord;
+        this.z = tile.zCoord;
+        this.dim = tile.getWorldObj().provider.dimensionId;
+    }
+
+    public WorldCoordinates(WorldCoordinates par1ChunkCoordinates)
+    {
+        this.x = par1ChunkCoordinates.x;
+        this.y = par1ChunkCoordinates.y;
+        this.z = par1ChunkCoordinates.z;
+        this.dim = par1ChunkCoordinates.dim;
+    }
+
+    public boolean equals(Object par1Obj)
+    {
+        if (!(par1Obj instanceof WorldCoordinates))
+        {
+            return false;
+        }
+        else
+        {
+        	WorldCoordinates coordinates = (WorldCoordinates)par1Obj;
+            return this.x == coordinates.x && this.y == coordinates.y && this.z == coordinates.z && this.dim == coordinates.dim ;
+        }
+    }
+
+    public int hashCode()
+    {
+        return this.x + this.y << 8 + this.z << 16 + this.dim << 24;
+    }
+
+    /**
+     * Compare the coordinate with another coordinate
+     */
+    public int compareWorldCoordinate(WorldCoordinates par1)
+    {
+        return this.dim == par1.dim ? (
+        		this.y == par1.y ? (this.z == par1.z ? this.x - par1.x : this.z - par1.z) : this.y - par1.y) : -1;
+    }
+
+    public void set(int par1, int par2, int par3, int d)
+    {
+        this.x = par1;
+        this.y = par2;
+        this.z = par3;
+        this.dim = d;
+    }
+
+    /**
+     * Returns the squared distance between this coordinates and the coordinates given as argument.
+     */
+    public float getDistanceSquared(int par1, int par2, int par3)
+    {
+        float f = (float)(this.x - par1);
+        float f1 = (float)(this.y - par2);
+        float f2 = (float)(this.z - par3);
+        return f * f + f1 * f1 + f2 * f2;
+    }
+
+    /**
+     * Return the squared distance between this coordinates and the ChunkCoordinates given as argument.
+     */
+    public float getDistanceSquaredToWorldCoordinates(WorldCoordinates par1ChunkCoordinates)
+    {
+        return this.getDistanceSquared(par1ChunkCoordinates.x, par1ChunkCoordinates.y, par1ChunkCoordinates.z);
+    }
+
+    public int compareTo(Object par1Obj)
+    {
+        return this.compareWorldCoordinate((WorldCoordinates)par1Obj);
+    }
+    
+    public void readNBT(NBTTagCompound nbt) {
+    	this.x = nbt.getInteger("w_x");
+    	this.y = nbt.getInteger("w_y");
+    	this.z = nbt.getInteger("w_z");
+    	this.dim = nbt.getInteger("w_d");
+    }
+    
+    public void writeNBT(NBTTagCompound nbt) {
+    	nbt.setInteger("w_x",x);
+    	nbt.setInteger("w_y",y);
+    	nbt.setInteger("w_z",z);
+    	nbt.setInteger("w_d",dim);
+    }
+    
+}

--- a/src/api/java/thaumcraft/api/aspects/Aspect.java
+++ b/src/api/java/thaumcraft/api/aspects/Aspect.java
@@ -1,0 +1,201 @@
+package thaumcraft.api.aspects;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+public class Aspect {
+	
+	String tag;
+	Aspect[] components;
+	int color;
+	private String chatcolor;
+	ResourceLocation image;
+	int blend;
+
+	/**
+	 * Use this constructor to register your own aspects.
+	 * @param tag the key that will be used to reference this aspect, as well as its latin display name
+	 * @param color color to display the tag in
+	 * @param components the aspects this one is formed from
+	 * @param image ResourceLocation pointing to a 32x32 icon of the aspect
+	 * @param blend GL11 blendmode (1 or 771). Used for rendering nodes. Default is 1
+	 */
+	public Aspect(String tag, int color, Aspect[] components, ResourceLocation image, int blend) {
+		if (aspects.containsKey(tag)) throw new IllegalArgumentException(tag+" already registered!");
+		this.tag = tag;
+		this.components = components;
+		this.color = color;
+		this.image = image;
+		this.blend = blend;
+		aspects.put(tag, this);
+	}
+	
+	/**
+	 * Shortcut constructor I use for the default aspects - you shouldn't be using this.
+	 */
+	public Aspect(String tag, int color, Aspect[] components) {
+		this(tag,color,components,new ResourceLocation("thaumcraft","textures/aspects/"+tag.toLowerCase()+".png"),1);
+	}
+	
+	/**
+	 * Shortcut constructor I use for the default aspects - you shouldn't be using this.
+	 */
+	public Aspect(String tag, int color, Aspect[] components, int blend) {
+		this(tag,color,components,new ResourceLocation("thaumcraft","textures/aspects/"+tag.toLowerCase()+".png"),blend);
+	}
+
+	/**
+	 * Shortcut constructor I use for the primal aspects - 
+	 * you shouldn't use this as making your own primal aspects will break all the things.
+	 */
+	public Aspect(String tag, int color, String chatcolor, int blend) {
+		this(tag,color,(Aspect[])null, blend);
+		this.setChatcolor(chatcolor);
+	}
+	
+	public int getColor() {
+		return color;
+	}
+	
+	public String getName() {
+		return WordUtils.capitalizeFully(tag);
+	}
+	
+	public String getLocalizedDescription() {
+		return StatCollector.translateToLocal("tc.aspect."+tag);
+	}
+	
+	public String getTag() {
+		return tag;
+	}
+
+	public void setTag(String tag) {
+		this.tag = tag;
+	}
+
+	public Aspect[] getComponents() {
+		return components;
+	}
+
+	public void setComponents(Aspect[] components) {
+		this.components = components;
+	}
+	
+	public ResourceLocation getImage() {
+		return image;
+	}
+	
+	public static Aspect getAspect(String tag) {
+		return aspects.get(tag);
+	}
+	
+	public int getBlend() {
+		return blend;
+	}
+
+	public void setBlend(int blend) {
+		this.blend = blend;
+	}
+	
+	public boolean isPrimal() {
+		return getComponents()==null || getComponents().length!=2;
+	}
+	
+	///////////////////////////////
+	public static ArrayList<Aspect> getPrimalAspects() {
+		ArrayList<Aspect> primals = new ArrayList<Aspect>();
+		Collection<Aspect> pa = aspects.values();
+		for (Aspect aspect:pa) {
+			if (aspect.isPrimal())  primals.add(aspect);
+		}
+		return primals;
+	}
+	
+	public static ArrayList<Aspect> getCompoundAspects() {
+		ArrayList<Aspect> compounds = new ArrayList<Aspect>();
+		Collection<Aspect> pa = aspects.values();
+		for (Aspect aspect:pa) {
+			if (!aspect.isPrimal())  compounds.add(aspect);
+		}
+		return compounds;
+	}
+
+	public String getChatcolor() {
+		return chatcolor;
+	}
+
+	public void setChatcolor(String chatcolor) {
+		this.chatcolor = chatcolor;
+	}
+	
+
+	///////////////////////////////
+	public static LinkedHashMap<String,Aspect> aspects = new LinkedHashMap<String,Aspect>();
+	
+	//PRIMAL
+		public static final Aspect AIR = new Aspect("aer",0xffff7e,"e",1);
+		public static final Aspect EARTH = new Aspect("terra",0x56c000,"2",1);
+		public static final Aspect FIRE = new Aspect("ignis",0xff5a01,"c",1);
+		public static final Aspect WATER = new Aspect("aqua",0x3cd4fc,"3",1);
+		public static final Aspect ORDER = new Aspect("ordo",0xd5d4ec,"7",1);
+		public static final Aspect ENTROPY = new Aspect("perditio",0x404040,"8",771);
+	
+	//SECONDARY  	
+		public static final Aspect VOID = new Aspect("vacuos",0x888888, new Aspect[] {AIR, ENTROPY},771);
+		public static final Aspect LIGHT = new Aspect("lux",0xfff663, new Aspect[] {AIR, FIRE});
+		public static final Aspect WEATHER = new Aspect("tempestas",0xFFFFFF, new Aspect[] {AIR, WATER});
+		public static final Aspect MOTION = new Aspect("motus",0xcdccf4, new Aspect[] {AIR, ORDER});
+		public static final Aspect COLD = new Aspect("gelum",0xe1ffff, new Aspect[] {FIRE, ENTROPY});
+		public static final Aspect CRYSTAL = new Aspect("vitreus",0x80ffff, new Aspect[] {EARTH, ORDER});
+		public static final Aspect LIFE = new Aspect("victus",0xde0005, new Aspect[] {WATER, EARTH});
+		public static final Aspect POISON = new Aspect("venenum",0x89f000,  new Aspect[] {WATER, ENTROPY});	
+		public static final Aspect ENERGY = new Aspect("potentia",0xc0ffff, new Aspect[] {ORDER, FIRE});
+		public static final Aspect EXCHANGE = new Aspect("permutatio",0x578357, new Aspect[] {ENTROPY, ORDER});
+//		public static final Aspect ?? = new Aspect("??",0xcdccf4, new Aspect[] {AIR, EARTH});
+//		public static final Aspect ?? = new Aspect("??",0xcdccf4, new Aspect[] {FIRE, EARTH});
+//		public static final Aspect ?? = new Aspect("??",0xcdccf4, new Aspect[] {FIRE, WATER});
+//		public static final Aspect ?? = new Aspect("??",0xcdccf4, new Aspect[] {ORDER, WATER});
+//		public static final Aspect ?? = new Aspect("??",0xcdccf4, new Aspect[] {EARTH, ENTROPY});
+		
+	//TERTIARY  			
+		public static final Aspect METAL = new Aspect("metallum",0xb5b5cd, new Aspect[] {EARTH, CRYSTAL});
+		public static final Aspect DEATH = new Aspect("mortuus",0x887788, new Aspect[] {LIFE, ENTROPY});
+		public static final Aspect FLIGHT = new Aspect("volatus",0xe7e7d7, new Aspect[] {AIR, MOTION});
+		public static final Aspect DARKNESS = new Aspect("tenebrae",0x222222, new Aspect[] {VOID, LIGHT});
+		public static final Aspect SOUL = new Aspect("spiritus",0xebebfb, new Aspect[] {LIFE, DEATH});
+		public static final Aspect HEAL = new Aspect("sano",0xff2f34, new Aspect[] {LIFE, ORDER});
+		public static final Aspect TRAVEL = new Aspect("iter",0xe0585b, new Aspect[] {MOTION, EARTH});
+		public static final Aspect ELDRITCH = new Aspect("alienis",0x805080, new Aspect[] {VOID, DARKNESS});
+		public static final Aspect MAGIC = new Aspect("praecantatio",0x9700c0, new Aspect[] {VOID, ENERGY});
+		public static final Aspect AURA = new Aspect("auram",0xffc0ff, new Aspect[] {MAGIC, AIR});
+		public static final Aspect TAINT = new Aspect("vitium",0x800080, new Aspect[] {MAGIC, ENTROPY});
+		public static final Aspect SLIME = new Aspect("limus",0x01f800, new Aspect[] {LIFE, WATER});
+		public static final Aspect PLANT = new Aspect("herba",0x01ac00, new Aspect[] {LIFE, EARTH});
+		public static final Aspect TREE = new Aspect("arbor",0x876531, new Aspect[] {AIR, PLANT});		
+		public static final Aspect BEAST = new Aspect("bestia",0x9f6409, new Aspect[] {MOTION, LIFE});
+		public static final Aspect FLESH = new Aspect("corpus",0xee478d, new Aspect[] {DEATH, BEAST});
+		public static final Aspect UNDEAD = new Aspect("exanimis",0x3a4000, new Aspect[] {MOTION, DEATH});
+		public static final Aspect MIND = new Aspect("cognitio",0xffc2b3, new Aspect[] {FIRE, SOUL});
+		public static final Aspect SENSES = new Aspect("sensus",0x0fd9ff, new Aspect[] {AIR, SOUL});
+		public static final Aspect MAN = new Aspect("humanus",0xffd7c0, new Aspect[] {BEAST, MIND});
+		public static final Aspect CROP = new Aspect("messis",0xe1b371, new Aspect[] {PLANT, MAN});		
+		public static final Aspect MINE = new Aspect("perfodio",0xdcd2d8, new Aspect[] {MAN, EARTH});
+		public static final Aspect TOOL = new Aspect("instrumentum",0x4040ee, new Aspect[] {MAN, ORDER});
+		public static final Aspect HARVEST = new Aspect("meto",0xeead82, new Aspect[] {CROP, TOOL});
+		public static final Aspect WEAPON = new Aspect("telum",0xc05050, new Aspect[] {TOOL, FIRE});
+		public static final Aspect ARMOR = new Aspect("tutamen",0x00c0c0, new Aspect[] {TOOL, EARTH});
+		public static final Aspect HUNGER = new Aspect("fames",0x9a0305, new Aspect[] {LIFE, VOID});
+		public static final Aspect GREED = new Aspect("lucrum",0xe6be44, new Aspect[] {MAN, HUNGER});
+		public static final Aspect CRAFT = new Aspect("fabrico",0x809d80, new Aspect[] {MAN, TOOL});
+		public static final Aspect CLOTH = new Aspect("pannus",0xeaeac2, new Aspect[] {TOOL, BEAST});
+		public static final Aspect MECHANISM = new Aspect("machina",0x8080a0, new Aspect[] {MOTION, TOOL});
+		public static final Aspect TRAP = new Aspect("vinculum",0x9a8080, new Aspect[] {MOTION, ENTROPY});				
+		
+		
+}

--- a/src/api/java/thaumcraft/api/aspects/AspectList.java
+++ b/src/api/java/thaumcraft/api/aspects/AspectList.java
@@ -1,0 +1,292 @@
+package thaumcraft.api.aspects;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import thaumcraft.api.ThaumcraftApiHelper;
+
+public class AspectList implements Serializable {
+	
+	public LinkedHashMap<Aspect,Integer> aspects = new LinkedHashMap<Aspect,Integer>();//aspects associated with this object
+
+	
+	/**
+	 * this creates a new aspect list with preloaded values based off the aspects of the given item.
+	 * @param the itemstack of the given item
+	 */
+	public AspectList(ItemStack stack) {
+		try {
+			AspectList temp = ThaumcraftApiHelper.getObjectAspects(stack);
+			if (temp!=null)
+			for (Aspect tag:temp.getAspects()) {
+				add(tag,temp.getAmount(tag));
+			}
+		} catch (Exception e) {}
+	}
+	
+	public AspectList() {
+	}
+	
+	public AspectList copy() {
+		AspectList out = new AspectList();
+		for (Aspect a:this.getAspects())
+			out.add(a, this.getAmount(a));
+		return out;
+	}
+	
+	/**
+	 * @return the amount of different aspects in this collection
+	 */
+	public int size() {
+		return aspects.size();
+	}
+	
+	/**
+	 * @return the amount of total vis in this collection
+	 */
+	public int visSize() {
+		int q = 0;
+		
+		for (Aspect as:aspects.keySet()) {
+			q+=this.getAmount(as);
+		}
+		
+		return q;
+	}
+	
+	/**
+	 * @return an array of all the aspects in this collection
+	 */
+	public Aspect[] getAspects() {
+		Aspect[] q = new Aspect[1];
+		return aspects.keySet().toArray(q);
+	}
+	
+	/**
+	 * @return an array of all the aspects in this collection
+	 */
+	public Aspect[] getPrimalAspects() {
+		AspectList t = new AspectList();
+		for (Aspect as:aspects.keySet()) {
+			if (as.isPrimal()) {
+				t.add(as,1);
+			}
+		}
+		Aspect[] q = new Aspect[1];
+		return t.aspects.keySet().toArray(q);
+	}
+	
+	/**
+	 * @return an array of all the aspects in this collection sorted by name
+	 */
+	public Aspect[] getAspectsSorted() {
+		try {
+			Aspect[] out = aspects.keySet().toArray(new Aspect[]{});
+			boolean change=false;
+			do {
+				change=false;
+				for(int a=0;a<out.length-1;a++) {
+					Aspect e1 = out[a];
+					Aspect e2 = out[a+1];
+					if (e1!=null && e2!=null && e1.getTag().compareTo(e2.getTag())>0) {
+						out[a] = e2;
+						out[a+1] = e1;
+						change = true;
+						break;
+					}
+				}
+			} while (change==true);
+			return out;
+		} catch (Exception e) {
+			return this.getAspects(); 
+		}
+	}
+	
+	/**
+	 * @return an array of all the aspects in this collection sorted by amount
+	 */
+	public Aspect[] getAspectsSortedAmount() {
+		try {
+			Aspect[] out = aspects.keySet().toArray(new Aspect[1]);
+			boolean change=false;
+			do {
+				change=false;
+				for(int a=0;a<out.length-1;a++) {
+					int e1 = getAmount(out[a]); 
+					int e2 = getAmount(out[a+1]);
+					if (e1>0 && e2>0 && e2>e1) {
+						Aspect ea = out[a];
+						Aspect eb = out[a+1];
+						out[a] = eb;
+						out[a+1] = ea;
+						change = true;
+						break;
+					}
+				}
+			} while (change==true);
+			return out;
+		} catch (Exception e) {
+			return this.getAspects();
+		}
+	}
+	
+	/**
+	 * @param key
+	 * @return the amount associated with the given aspect in this collection
+	 */
+	public int getAmount(Aspect key) {
+		return  aspects.get(key)==null?0:aspects.get(key);
+	}
+	
+	/**
+	 * Reduces the amount of an aspect in this collection by the given amount. 
+	 * @param key
+	 * @param amount
+	 * @return 
+	 */
+	public boolean reduce(Aspect key, int amount) {
+		if (getAmount(key)>=amount) {
+			int am = getAmount(key)-amount;
+			aspects.put(key, am);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Reduces the amount of an aspect in this collection by the given amount. 
+	 * If reduced to 0 or less the aspect will be removed completely. 
+	 * @param key
+	 * @param amount
+	 * @return
+	 */
+	public AspectList remove(Aspect key, int amount) {
+		int am = getAmount(key)-amount;
+		if (am<=0) aspects.remove(key); else
+		this.aspects.put(key, am);
+		return this;
+	}
+	
+	/**
+	 * Simply removes the aspect from the list
+	 * @param key
+	 * @param amount
+	 * @return
+	 */
+	public AspectList remove(Aspect key) {
+		aspects.remove(key); 
+		return this;
+	}
+	
+	/**
+	 * Adds this aspect and amount to the collection. 
+	 * If the aspect exists then its value will be increased by the given amount.
+	 * @param aspect
+	 * @param amount
+	 * @return
+	 */
+	public AspectList add(Aspect aspect, int amount) {
+		if (this.aspects.containsKey(aspect)) {
+			int oldamount = this.aspects.get(aspect);
+			amount+=oldamount;
+		}
+		this.aspects.put( aspect, amount );
+		return this;
+	}
+
+	
+	/**
+	 * Adds this aspect and amount to the collection. 
+	 * If the aspect exists then only the highest of the old or new amount will be used.
+	 * @param aspect
+	 * @param amount
+	 * @return
+	 */
+	public AspectList merge(Aspect aspect, int amount) {
+		if (this.aspects.containsKey(aspect)) {
+			int oldamount = this.aspects.get(aspect);
+			if (amount<oldamount) amount=oldamount;
+			
+		}
+		this.aspects.put( aspect, amount );
+		return this;
+	}
+	
+	public AspectList add(AspectList in) {
+		for (Aspect a:in.getAspects()) 
+			this.add(a, in.getAmount(a));
+		return this;
+	}
+	
+	public AspectList merge(AspectList in) {
+		for (Aspect a:in.getAspects()) 
+			this.merge(a, in.getAmount(a));
+		return this;
+	}
+	
+	/**
+	 * Reads the list of aspects from nbt
+	 * @param nbttagcompound
+	 * @return 
+	 */
+	public void readFromNBT(NBTTagCompound nbttagcompound)
+    {
+        aspects.clear();
+        NBTTagList tlist = nbttagcompound.getTagList("Aspects",(byte)10);
+		for (int j = 0; j < tlist.tagCount(); j++) {
+			NBTTagCompound rs = (NBTTagCompound) tlist.getCompoundTagAt(j);
+			if (rs.hasKey("key")) {
+				add(	Aspect.getAspect(rs.getString("key")),
+						rs.getInteger("amount"));
+			}
+		}
+    }
+	
+	public void readFromNBT(NBTTagCompound nbttagcompound, String label)
+    {
+        aspects.clear();
+        NBTTagList tlist = nbttagcompound.getTagList(label,(byte)10);
+		for (int j = 0; j < tlist.tagCount(); j++) {
+			NBTTagCompound rs = (NBTTagCompound) tlist.getCompoundTagAt(j);
+			if (rs.hasKey("key")) {
+				add(	Aspect.getAspect(rs.getString("key")),
+						rs.getInteger("amount"));
+			}
+		}
+    }
+	
+	/**
+	 * Writes the list of aspects to nbt
+	 * @param nbttagcompound
+	 * @return 
+	 */
+	public void writeToNBT(NBTTagCompound nbttagcompound)
+    {
+        NBTTagList tlist = new NBTTagList();
+		nbttagcompound.setTag("Aspects", tlist);
+		for (Aspect aspect : getAspects())
+			if (aspect != null) {
+				NBTTagCompound f = new NBTTagCompound();
+				f.setString("key", aspect.getTag());
+				f.setInteger("amount", getAmount(aspect));
+				tlist.appendTag(f);
+			}
+    }
+	
+	public void writeToNBT(NBTTagCompound nbttagcompound, String label)
+    {
+        NBTTagList tlist = new NBTTagList();
+		nbttagcompound.setTag(label, tlist);
+		for (Aspect aspect : getAspects())
+			if (aspect != null) {
+				NBTTagCompound f = new NBTTagCompound();
+				f.setString("key", aspect.getTag());
+				f.setInteger("amount", getAmount(aspect));
+				tlist.appendTag(f);
+			}
+    }
+	
+}

--- a/src/api/java/thaumcraft/api/aspects/AspectSourceHelper.java
+++ b/src/api/java/thaumcraft/api/aspects/AspectSourceHelper.java
@@ -1,0 +1,58 @@
+package thaumcraft.api.aspects;
+
+import java.lang.reflect.Method;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import cpw.mods.fml.common.FMLLog;
+
+public class AspectSourceHelper {
+
+	static Method drainEssentia;
+	static Method findEssentia;
+	/**
+	 * This method is what is used to drain essentia from jars and other sources for things like 
+	 * infusion crafting or powering the arcane furnace. A record of possible sources are kept track of
+	 * and refreshed as needed around the calling tile entity. This also renders the essentia trail particles.
+	 * Only 1 essentia is drained at a time
+	 * @param tile the tile entity that is draining the essentia
+	 * @param aspect the aspect that you are looking for
+	 * @param direction the direction from which you wish to drain. Forgedirection.Unknown simply seeks in all directions. 
+	 * @param range how many blocks you wish to search for essentia sources. 
+	 * @return boolean returns true if essentia was found and removed from a source.
+	 */
+	public static boolean drainEssentia(TileEntity tile, Aspect aspect, ForgeDirection direction, int range) {
+	    try {
+	        if(drainEssentia == null) {
+	            Class fake = Class.forName("thaumcraft.common.lib.events.EssentiaHandler");
+	            drainEssentia = fake.getMethod("drainEssentia", TileEntity.class, Aspect.class, ForgeDirection.class, int.class);
+	        }
+	        return (Boolean) drainEssentia.invoke(null, tile, aspect, direction, range);
+	    } catch(Exception ex) { 
+	    	FMLLog.warning("[Thaumcraft API] Could not invoke thaumcraft.common.lib.events.EssentiaHandler method drainEssentia");
+	    }
+		return false;
+	}
+	
+	/**
+	 * This method returns if there is any essentia of the passed type that can be drained. It in no way checks how
+	 * much there is, only if an essentia container nearby contains at least 1 point worth.
+	 * @param tile the tile entity that is checking the essentia
+	 * @param aspect the aspect that you are looking for
+	 * @param direction the direction from which you wish to drain. Forgedirection.Unknown simply seeks in all directions. 
+	 * @param range how many blocks you wish to search for essentia sources. 
+	 * @return boolean returns true if essentia was found and removed from a source.
+	 */
+	public static boolean findEssentia(TileEntity tile, Aspect aspect, ForgeDirection direction, int range) {
+	    try {
+	        if(findEssentia == null) {
+	            Class fake = Class.forName("thaumcraft.common.lib.events.EssentiaHandler");
+	            findEssentia = fake.getMethod("findEssentia", TileEntity.class, Aspect.class, ForgeDirection.class, int.class);
+	        }
+	        return (Boolean) findEssentia.invoke(null, tile, aspect, direction, range);
+	    } catch(Exception ex) { 
+	    	FMLLog.warning("[Thaumcraft API] Could not invoke thaumcraft.common.lib.events.EssentiaHandler method findEssentia");
+	    }
+		return false;
+	}
+}

--- a/src/api/java/thaumcraft/api/aspects/IAspectContainer.java
+++ b/src/api/java/thaumcraft/api/aspects/IAspectContainer.java
@@ -1,0 +1,80 @@
+package thaumcraft.api.aspects;
+
+
+/**
+ * 
+ * @author azanor
+ * 
+ * Used by blocks like the crucible and alembic to hold their aspects. 
+ * Tiles extending this interface will have their aspects show up when viewed by goggles of revealing
+ *
+ */
+public interface IAspectContainer {
+	public AspectList getAspects();
+	
+	
+	public void setAspects(AspectList aspects);
+	
+	
+	/**
+	 * This method is used to determine of a specific aspect can be added to this container.
+	 * @param tag 
+	 * @return true or false
+	 */
+	public boolean doesContainerAccept(Aspect tag);
+	
+	/**
+	 * This method is used to add a certain amount of an aspect to the tile entity.
+	 * @param tag 
+	 * @param amount
+	 * @return the amount of aspect left over that could not be added.
+	 */
+	public int addToContainer(Aspect tag, int amount);
+
+	/**
+	 * Removes a certain amount of a specific aspect from the tile entity
+	 * @param tag
+	 * @param amount
+	 * @return true if that amount of aspect was available and was removed
+	 */
+	public boolean takeFromContainer(Aspect tag, int amount);
+	
+	/**
+	 * removes a bunch of different aspects and amounts from the tile entity.
+	 * @param ot the ObjectTags object that contains the aspects and their amounts.
+	 * @return true if all the aspects and their amounts were available and successfully removed
+	 * 
+	 * Going away in the next major patch
+	 */
+	@Deprecated
+	public boolean takeFromContainer(AspectList ot);
+	
+	/**
+	 * Checks if the tile entity contains the listed amount (or more) of the aspect
+	 * @param tag
+	 * @param amount
+	 * @return
+	 */
+	public boolean doesContainerContainAmount(Aspect tag,int amount);
+	
+	/**
+	 * Checks if the tile entity contains all the listed aspects and their amounts
+	 * @param ot the ObjectTags object that contains the aspects and their amounts.
+	 * @return
+	 * 
+	 * Going away in the next major patch
+	 */
+	@Deprecated
+	public boolean doesContainerContain(AspectList ot);
+	
+	/**
+	 * Returns how much of the aspect this tile entity contains
+	 * @param tag
+	 * @return the amount of that aspect found
+	 */
+	public int containerContains(Aspect tag);
+	
+}
+
+
+

--- a/src/api/java/thaumcraft/api/aspects/IAspectSource.java
+++ b/src/api/java/thaumcraft/api/aspects/IAspectSource.java
@@ -1,0 +1,16 @@
+package thaumcraft.api.aspects;
+
+
+
+/**
+ * @author Azanor
+ * 
+ * This interface is implemented by tile entites (or possibly anything else) like jars
+ * so that they can act as an essentia source for blocks like the infusion altar.
+ *
+ */
+public interface IAspectSource extends IAspectContainer {
+	
+	
+	
+}

--- a/src/api/java/thaumcraft/api/aspects/IEssentiaContainerItem.java
+++ b/src/api/java/thaumcraft/api/aspects/IEssentiaContainerItem.java
@@ -1,0 +1,37 @@
+package thaumcraft.api.aspects;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * 
+ * @author azanor
+ * 
+ * Used by wispy essences and essentia phials to hold their aspects. 
+ * Useful for similar item containers that store their aspect information in nbt form so TC
+ * automatically picks up the aspects they contain
+ *
+ */
+public interface IEssentiaContainerItem {
+	public AspectList getAspects(ItemStack itemstack);
+	public void setAspects(ItemStack itemstack, AspectList aspects);
+}
+
+//Example implementation
+/*  
+	@Override
+	public AspectList getAspects(ItemStack itemstack) {
+		if (itemstack.hasTagCompound()) {
+			AspectList aspects = new AspectList();
+			aspects.readFromNBT(itemstack.getTagCompound());
+			return aspects.size()>0?aspects:null;
+		}
+		return null;
+	}
+	
+	@Override
+	public void setAspects(ItemStack itemstack, AspectList aspects) {
+		if (!itemstack.hasTagCompound()) itemstack.setTagCompound(new NBTTagCompound());
+		aspects.writeToNBT(itemstack.getTagCompound());
+	}
+*/

--- a/src/api/java/thaumcraft/api/aspects/IEssentiaTransport.java
+++ b/src/api/java/thaumcraft/api/aspects/IEssentiaTransport.java
@@ -1,0 +1,100 @@
+package thaumcraft.api.aspects;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+
+/**
+ * @author Azanor
+ * This interface is used by tiles that use or transport vis. 
+ * Only tiles that implement this interface will be able to connect to vis conduits or other thaumic devices
+ */
+public interface IEssentiaTransport {
+	/**
+	 * Is this tile able to connect to other vis users/sources on the specified side?
+	 * @param face
+	 * @return
+	 */
+	public boolean isConnectable(ForgeDirection face);
+	
+	/**
+	 * Is this side used to input essentia?
+	 * @param face
+	 * @return
+	 */
+	boolean canInputFrom(ForgeDirection face);
+	
+	/**
+	 * Is this side used to output essentia?
+	 * @param face
+	 * @return
+	 */
+	boolean canOutputTo(ForgeDirection face);
+			
+	/**
+	 * Sets the amount of suction this block will apply
+	 * @param suction
+	 */
+	public void setSuction(Aspect aspect, int amount);
+	
+	/**
+	 * Returns the type of suction this block is applying. 
+	 * @param loc
+	 * 		the location from where the suction is being checked
+	 * @return
+	 * 		a return type of null indicates the suction is untyped and the first thing available will be drawn
+	 */
+	public Aspect getSuctionType(ForgeDirection face);
+	
+	/**
+	 * Returns the strength of suction this block is applying. 
+	 * @param loc
+	 * 		the location from where the suction is being checked
+	 * @return
+	 */
+	public int getSuctionAmount(ForgeDirection face);
+	
+	/**
+	 * remove the specified amount of essentia from this transport tile
+	 * @return how much was actually taken
+	 */
+	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face);
+	
+	/**
+	 * add the specified amount of essentia to this transport tile
+	 * @return how much was actually added
+	 */
+	public int addEssentia(Aspect aspect, int amount, ForgeDirection face);
+	
+	/**
+	 * What type of essentia this contains
+	 * @param face
+	 * @return
+	 */
+	public Aspect getEssentiaType(ForgeDirection face);
+	
+	/**
+	 * How much essentia this block contains
+	 * @param face
+	 * @return
+	 */
+	public int getEssentiaAmount(ForgeDirection face);
+	
+	
+
+	/**
+	 * Essentia will not be drawn from this container unless the suction exceeds this amount.
+	 * @return the amount
+	 */
+	public int getMinimumSuction();
+
+	/**
+	 * Return true if you want the conduit to extend a little further into the block. 
+	 * Used by jars and alembics that have smaller than normal hitboxes
+	 * @return
+	 */
+	boolean renderExtendedTube();
+
+	
+	
+}
+

--- a/src/api/java/thaumcraft/api/crafting/CrucibleRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/CrucibleRecipe.java
@@ -1,0 +1,91 @@
+package thaumcraft.api.crafting;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public class CrucibleRecipe {
+
+	private ItemStack recipeOutput;
+	
+	public Object catalyst;
+	public AspectList aspects;
+	public String key;
+	
+	public int hash;
+	
+	public CrucibleRecipe(String researchKey, ItemStack result, Object cat, AspectList tags) {
+		recipeOutput = result;
+		this.aspects = tags;
+		this.key = researchKey;
+		this.catalyst = cat;
+		if (cat instanceof String) {
+			this.catalyst = OreDictionary.getOres((String) cat);
+		}
+		String hc = researchKey + result.toString();
+		for (Aspect tag:tags.getAspects()) {
+			hc += tag.getTag()+tags.getAmount(tag);
+		}
+		if (cat instanceof ItemStack) {
+			hc += ((ItemStack)cat).toString();
+		} else
+		if (cat instanceof ArrayList && ((ArrayList<ItemStack>)catalyst).size()>0) {
+			for (ItemStack is :(ArrayList<ItemStack>)catalyst) {
+				hc += is.toString();
+			}
+		}
+		
+		hash = hc.hashCode();
+	}
+	
+		
+
+	public boolean matches(AspectList itags, ItemStack cat) {
+		if (catalyst instanceof ItemStack &&
+				!ThaumcraftApiHelper.itemMatches((ItemStack) catalyst,cat,false)) {
+			return false;
+		} else 
+		if (catalyst instanceof ArrayList && ((ArrayList<ItemStack>)catalyst).size()>0) {
+			ItemStack[] ores = ((ArrayList<ItemStack>)catalyst).toArray(new ItemStack[]{});
+			if (!ThaumcraftApiHelper.containsMatch(false, new ItemStack[]{cat},ores)) return false;
+		}
+		if (itags==null) return false;
+		for (Aspect tag:aspects.getAspects()) {
+			if (itags.getAmount(tag)<aspects.getAmount(tag)) return false;
+		}
+		return true;
+	}
+	
+	public boolean catalystMatches(ItemStack cat) {
+		if (catalyst instanceof ItemStack && ThaumcraftApiHelper.itemMatches((ItemStack) catalyst,cat,false)) {
+			return true;
+		} else 
+		if (catalyst instanceof ArrayList && ((ArrayList<ItemStack>)catalyst).size()>0) {
+			ItemStack[] ores = ((ArrayList<ItemStack>)catalyst).toArray(new ItemStack[]{});
+			if (ThaumcraftApiHelper.containsMatch(false, new ItemStack[]{cat},ores)) return true;
+		}
+		return false;
+	}
+	
+	public AspectList removeMatching(AspectList itags) {
+		AspectList temptags = new AspectList();
+		temptags.aspects.putAll(itags.aspects);
+		
+		for (Aspect tag:aspects.getAspects()) {
+			temptags.remove(tag, aspects.getAmount(tag));
+		}
+		
+		itags = temptags;
+		return itags;
+	}
+	
+	public ItemStack getRecipeOutput() {
+		return recipeOutput;
+	}
+	
+
+}

--- a/src/api/java/thaumcraft/api/crafting/IArcaneRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/IArcaneRecipe.java
@@ -1,0 +1,35 @@
+package thaumcraft.api.crafting;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import thaumcraft.api.aspects.AspectList;
+
+public interface IArcaneRecipe
+{
+	
+	
+    /**
+     * Used to check if a recipe matches current crafting inventory
+     * @param player 
+     */
+    boolean matches(IInventory var1, World world, EntityPlayer player);
+
+    /**
+     * Returns an Item that is the result of this recipe
+     */
+    ItemStack getCraftingResult(IInventory var1);
+
+    /**
+     * Returns the size of the recipe area
+     */
+    int getRecipeSize();
+
+    ItemStack getRecipeOutput();
+    AspectList getAspects();
+    AspectList getAspects(IInventory var1);
+    String getResearch();
+
+    
+}

--- a/src/api/java/thaumcraft/api/crafting/IInfusionStabiliser.java
+++ b/src/api/java/thaumcraft/api/crafting/IInfusionStabiliser.java
@@ -1,0 +1,19 @@
+package thaumcraft.api.crafting;
+
+import net.minecraft.world.World;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Blocks that implement this interface act as infusion crafting stabilisers like candles and skulls 
+ *
+ */
+public interface IInfusionStabiliser {
+	
+	/**
+	 * returns true if the block can stabilise things
+	 */
+	public boolean canStabaliseInfusion(World world, int x, int y, int z);
+
+}

--- a/src/api/java/thaumcraft/api/crafting/InfusionEnchantmentRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/InfusionEnchantmentRecipe.java
@@ -1,0 +1,154 @@
+package thaumcraft.api.crafting;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.aspects.AspectList;
+
+public class InfusionEnchantmentRecipe
+{
+	
+	public AspectList aspects;
+	public String research;
+	public ItemStack[] components;
+	public Enchantment enchantment;
+	public int recipeXP;
+	public int instability;
+	
+	public InfusionEnchantmentRecipe(String research, Enchantment input, int inst, 
+			AspectList aspects2, ItemStack[] recipe) {
+		this.research = research;
+		this.enchantment = input;
+		this.aspects = aspects2;
+		this.components = recipe;
+		this.instability = inst;
+		this.recipeXP = Math.max(1, input.getMinEnchantability(1)/3);
+	}
+
+	/**
+     * Used to check if a recipe matches current crafting inventory
+     * @param player 
+     */
+	public boolean matches(ArrayList<ItemStack> input, ItemStack central, World world, EntityPlayer player) {
+		if (research.length()>0 && !ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), research)) {
+    		return false;
+    	}
+		
+		if (!enchantment.canApply(central) || !central.getItem().isItemTool(central)) {
+			return false;
+		}
+				
+		Map map1 = EnchantmentHelper.getEnchantments(central);
+		Iterator iterator = map1.keySet().iterator();
+        while (iterator.hasNext())
+        {
+        	int j1 = ((Integer)iterator.next()).intValue();
+            Enchantment ench = Enchantment.enchantmentsList[j1];
+            if (j1 == enchantment.effectId &&
+            		EnchantmentHelper.getEnchantmentLevel(j1, central)>=ench.getMaxLevel())
+            	return false;
+            if (enchantment.effectId != ench.effectId && 
+            	(!enchantment.canApplyTogether(ench) ||
+            	!ench.canApplyTogether(enchantment))) {
+            	return false;
+            }
+        }
+		
+		ItemStack i2 = null;
+		
+		ArrayList<ItemStack> ii = new ArrayList<ItemStack>();
+		for (ItemStack is:input) {
+			ii.add(is.copy());
+		}
+		
+		for (ItemStack comp:components) {
+			boolean b=false;
+			for (int a=0;a<ii.size();a++) {
+				 i2 = ii.get(a).copy();
+				if (comp.getItemDamage()==OreDictionary.WILDCARD_VALUE) {
+					i2.setItemDamage(OreDictionary.WILDCARD_VALUE);
+				}
+				if (areItemStacksEqual(i2, comp,true)) {
+					ii.remove(a);
+					b=true;
+					break;
+				}
+			}
+			if (!b) return false;
+		}
+//		System.out.println(ii.size());
+		return ii.size()==0?true:false;
+    }
+	
+	protected boolean areItemStacksEqual(ItemStack stack0, ItemStack stack1, boolean fuzzy)
+    {
+		if (stack0==null && stack1!=null) return false;
+		if (stack0!=null && stack1==null) return false;
+		if (stack0==null && stack1==null) return true;
+		boolean t1=ThaumcraftApiHelper.areItemStackTagsEqualForCrafting(stack0, stack1);
+		if (!t1) return false;
+		if (fuzzy) {
+			Integer od = OreDictionary.getOreID(stack0);
+			if (od!=-1) {
+				ItemStack[] ores = OreDictionary.getOres(od).toArray(new ItemStack[]{});
+				if (ThaumcraftApiHelper.containsMatch(false, new ItemStack[]{stack1}, ores))
+					return true;
+			}
+		}
+        return stack0.getItem() != stack1.getItem() ? false : (stack0.getItemDamage() != stack1.getItemDamage() ? false : stack0.stackSize <= stack0.getMaxStackSize() );
+    }
+	
+   
+    public Enchantment getEnchantment() {
+		return enchantment;
+    	
+    }
+    
+    public AspectList getAspects() {
+		return aspects;
+    	
+    }
+    
+    public String getResearch() {
+		return research;
+    	
+    }
+
+	public int calcInstability(ItemStack recipeInput) {
+		int i = 0;
+		Map map1 = EnchantmentHelper.getEnchantments(recipeInput);
+		Iterator iterator = map1.keySet().iterator();
+        while (iterator.hasNext())
+        {
+        	int j1 = ((Integer)iterator.next()).intValue();
+        	i += EnchantmentHelper.getEnchantmentLevel(j1, recipeInput);
+        }
+		return (i/2) + instability;
+	}
+
+	public int calcXP(ItemStack recipeInput) {
+		return recipeXP * (1+EnchantmentHelper.getEnchantmentLevel(enchantment.effectId, recipeInput));
+	}
+
+	public float getEssentiaMod(ItemStack recipeInput) {
+		float mod = EnchantmentHelper.getEnchantmentLevel(enchantment.effectId, recipeInput);
+		Map map1 = EnchantmentHelper.getEnchantments(recipeInput);
+		Iterator iterator = map1.keySet().iterator();
+        while (iterator.hasNext())
+        {
+        	int j1 = ((Integer)iterator.next()).intValue();
+        	if (j1 != enchantment.effectId)
+        		mod += EnchantmentHelper.getEnchantmentLevel(j1, recipeInput) * .1f;
+        }
+		return mod;
+	}
+
+}

--- a/src/api/java/thaumcraft/api/crafting/InfusionRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/InfusionRecipe.java
@@ -1,0 +1,133 @@
+package thaumcraft.api.crafting;
+
+import java.util.ArrayList;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.aspects.AspectList;
+
+public class InfusionRecipe
+{
+	protected AspectList aspects;
+	protected String research;
+	private ItemStack[] components;
+	private ItemStack recipeInput;
+	protected Object recipeOutput;
+	protected int instability;
+	
+	public InfusionRecipe(String research, Object output, int inst,
+			AspectList aspects2, ItemStack input, ItemStack[] recipe) {
+		this.research = research;
+		this.recipeOutput = output;
+		this.recipeInput = input;
+		this.aspects = aspects2;
+		this.components = recipe;
+		this.instability = inst;
+	}
+
+	/**
+     * Used to check if a recipe matches current crafting inventory
+     * @param player 
+     */
+	public boolean matches(ArrayList<ItemStack> input, ItemStack central, World world, EntityPlayer player) {
+		if (getRecipeInput()==null) return false;
+			
+		if (research.length()>0 && !ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), research)) {
+    		return false;
+    	}
+		
+		ItemStack i2 = central.copy();
+		if (getRecipeInput().getItemDamage()==OreDictionary.WILDCARD_VALUE) {
+			i2.setItemDamage(OreDictionary.WILDCARD_VALUE);
+		}
+		
+		if (!areItemStacksEqual(i2, getRecipeInput(), true)) return false;
+		
+		ArrayList<ItemStack> ii = new ArrayList<ItemStack>();
+		for (ItemStack is:input) {
+			ii.add(is.copy());
+		}
+		
+		for (ItemStack comp:getComponents()) {
+			boolean b=false;
+			for (int a=0;a<ii.size();a++) {
+				 i2 = ii.get(a).copy();
+				if (comp.getItemDamage()==OreDictionary.WILDCARD_VALUE) {
+					i2.setItemDamage(OreDictionary.WILDCARD_VALUE);
+				}
+				if (areItemStacksEqual(i2, comp,true)) {
+					ii.remove(a);
+					b=true;
+					break;
+				}
+			}
+			if (!b) return false;
+		}
+		return ii.size()==0?true:false;
+    }
+	
+	public static boolean areItemStacksEqual(ItemStack stack0, ItemStack stack1, boolean fuzzy)
+    {
+		if (stack0==null && stack1!=null) return false;
+		if (stack0!=null && stack1==null) return false;
+		if (stack0==null && stack1==null) return true;
+		
+		//nbt
+		boolean t1=ThaumcraftApiHelper.areItemStackTagsEqualForCrafting(stack0, stack1);		
+		if (!t1) return false;
+		
+		if (fuzzy) {
+			Integer od = OreDictionary.getOreID(stack0);
+			if (od!=-1) {
+				ItemStack[] ores = OreDictionary.getOres(od).toArray(new ItemStack[]{});
+				if (ThaumcraftApiHelper.containsMatch(false, new ItemStack[]{stack1}, ores))
+					return true;
+			}
+		}
+		
+		//damage
+		boolean damage = stack0.getItemDamage() == stack1.getItemDamage() ||
+				stack1.getItemDamage() == OreDictionary.WILDCARD_VALUE;		
+		
+        return stack0.getItem() != stack1.getItem() ? false : (!damage ? false : stack0.stackSize <= stack0.getMaxStackSize() );
+    }
+	   
+    public Object getRecipeOutput() {
+		return getRecipeOutput(this.getRecipeInput());
+    }
+    
+    public AspectList getAspects() {
+		return getAspects(this.getRecipeInput());
+    }
+
+    public int getInstability() {
+		return getInstability(this.getRecipeInput());
+    }
+    
+    public String getResearch() {
+		return research;
+    }
+    
+	public ItemStack getRecipeInput() {
+		return recipeInput;
+	}
+
+	public ItemStack[] getComponents() {
+		return components;
+	}
+	
+	public Object getRecipeOutput(ItemStack input) {
+		return recipeOutput;
+    }
+    
+    public AspectList getAspects(ItemStack input) {
+		return aspects;
+    }
+    
+    public int getInstability(ItemStack input) {
+		return instability;
+    }
+}

--- a/src/api/java/thaumcraft/api/crafting/ShapedArcaneRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/ShapedArcaneRecipe.java
@@ -1,0 +1,261 @@
+package thaumcraft.api.crafting;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.aspects.AspectList;
+
+public class ShapedArcaneRecipe implements IArcaneRecipe
+{
+    //Added in for future ease of change, but hard coded for now.
+    private static final int MAX_CRAFT_GRID_WIDTH = 3;
+    private static final int MAX_CRAFT_GRID_HEIGHT = 3;
+
+    public ItemStack output = null;
+    public  Object[] input = null;
+    public AspectList aspects = null;
+    public String research; 
+    public int width = 0;
+    public int height = 0;
+    private boolean mirrored = true;
+
+    public ShapedArcaneRecipe(String research, Block     result, AspectList aspects, Object... recipe){ this(research, new ItemStack(result), aspects, recipe); }
+    public ShapedArcaneRecipe(String research, Item      result, AspectList aspects, Object... recipe){ this(research, new ItemStack(result), aspects, recipe); }
+    public ShapedArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe)
+    {
+        output = result.copy();
+        this.research = research;
+        this.aspects = aspects;
+        String shape = "";
+        
+        int idx = 0;
+
+        if (recipe[idx] instanceof Boolean)
+        {
+            mirrored = (Boolean)recipe[idx];
+            if (recipe[idx+1] instanceof Object[])
+            {
+                recipe = (Object[])recipe[idx+1];
+            }
+            else
+            {
+                idx = 1;
+            }
+        }
+
+        if (recipe[idx] instanceof String[])
+        {
+            String[] parts = ((String[])recipe[idx++]);
+
+            for (String s : parts)
+            {
+                width = s.length();
+                shape += s;
+            }
+
+            height = parts.length;
+        }
+        else
+        {
+            while (recipe[idx] instanceof String)
+            {
+                String s = (String)recipe[idx++];
+                shape += s;
+                width = s.length();
+                height++;
+            }
+        }
+
+        if (width * height != shape.length())
+        {
+            String ret = "Invalid shaped ore recipe: ";
+            for (Object tmp :  recipe)
+            {
+                ret += tmp + ", ";
+            }
+            ret += output;
+            throw new RuntimeException(ret);
+        }
+
+        HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
+
+        for (; idx < recipe.length; idx += 2)
+        {
+            Character chr = (Character)recipe[idx];
+            Object in = recipe[idx + 1];
+
+            if (in instanceof ItemStack)
+            {
+                itemMap.put(chr, ((ItemStack)in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                itemMap.put(chr, new ItemStack((Item)in));
+            }
+            else if (in instanceof Block)
+            {
+                itemMap.put(chr, new ItemStack((Block)in, 1, OreDictionary.WILDCARD_VALUE));
+            }
+            else if (in instanceof String)
+            {
+                itemMap.put(chr, OreDictionary.getOres((String)in));
+            }
+            else
+            {
+                String ret = "Invalid shaped ore recipe: ";
+                for (Object tmp :  recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+
+        input = new Object[width * height];
+        int x = 0;
+        for (char chr : shape.toCharArray())
+        {
+            input[x++] = itemMap.get(chr);
+        }
+    }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory var1){ return output.copy(); }
+
+    @Override
+    public int getRecipeSize(){ return input.length; }
+
+    @Override
+    public ItemStack getRecipeOutput(){ return output; }
+
+    @Override
+    public boolean matches(IInventory inv, World world, EntityPlayer player)
+    {
+    	if (research.length()>0 && !ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), research)) {
+    		return false;
+    	}
+        for (int x = 0; x <= MAX_CRAFT_GRID_WIDTH - width; x++)
+        {
+            for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y)
+            {
+                if (checkMatch(inv, x, y, false))
+                {
+                    return true;
+                }
+
+                if (mirrored && checkMatch(inv, x, y, true))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean checkMatch(IInventory inv, int startX, int startY, boolean mirror)
+    {
+        for (int x = 0; x < MAX_CRAFT_GRID_WIDTH; x++)
+        {
+            for (int y = 0; y < MAX_CRAFT_GRID_HEIGHT; y++)
+            {
+                int subX = x - startX;
+                int subY = y - startY;
+                Object target = null;
+
+                if (subX >= 0 && subY >= 0 && subX < width && subY < height)
+                {
+                    if (mirror)
+                    {
+                        target = input[width - subX - 1 + subY * width];
+                    }
+                    else
+                    {
+                        target = input[subX + subY * width];
+                    }
+                }
+
+                ItemStack slot = ThaumcraftApiHelper.getStackInRowAndColumn(inv, x, y);
+
+                if (target instanceof ItemStack)
+                {
+                    if (!checkItemEquals((ItemStack)target, slot))
+                    {
+                        return false;
+                    }
+                }
+                else if (target instanceof ArrayList)
+                {
+                    boolean matched = false;
+
+                    for (ItemStack item : (ArrayList<ItemStack>)target)
+                    {
+                        matched = matched || checkItemEquals(item, slot);
+                    }
+
+                    if (!matched)
+                    {
+                        return false;
+                    }
+                }
+                else if (target == null && slot != null)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private boolean checkItemEquals(ItemStack target, ItemStack input)
+    {
+        if (input == null && target != null || input != null && target == null)
+        {
+            return false;
+        }
+        return (target.getItem() == input.getItem() && 
+        		(!target.hasTagCompound() || ThaumcraftApiHelper.areItemStackTagsEqualForCrafting(input,target)) &&
+        		(target.getItemDamage() == OreDictionary.WILDCARD_VALUE|| target.getItemDamage() == input.getItemDamage()));
+    }
+
+    public ShapedArcaneRecipe setMirrored(boolean mirror)
+    {
+        mirrored = mirror;
+        return this;
+    }
+
+    /**
+     * Returns the input for this recipe, any mod accessing this value should never
+     * manipulate the values in this array as it will effect the recipe itself.
+     * @return The recipes input vales.
+     */
+    public Object[] getInput()
+    {
+        return this.input;
+    }
+    
+    @Override		
+	public AspectList getAspects() {
+		return aspects;
+	}
+    
+    @Override		
+	public AspectList getAspects(IInventory inv) {
+		return aspects;
+	}
+	
+	@Override
+	public String getResearch() {
+		return research;
+	}
+}

--- a/src/api/java/thaumcraft/api/crafting/ShapelessArcaneRecipe.java
+++ b/src/api/java/thaumcraft/api/crafting/ShapelessArcaneRecipe.java
@@ -1,0 +1,161 @@
+package thaumcraft.api.crafting;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.aspects.AspectList;
+
+public class ShapelessArcaneRecipe implements IArcaneRecipe
+{
+    private ItemStack output = null;
+    private ArrayList input = new ArrayList();
+    
+    public AspectList aspects = null;
+    public String research; 
+
+    public ShapelessArcaneRecipe(String research, Block result, AspectList aspects, Object... recipe){ this(research,new ItemStack(result),aspects, recipe); }
+    public ShapelessArcaneRecipe(String research, Item  result, AspectList aspects, Object... recipe){ this(research,new ItemStack(result),aspects, recipe); }
+
+    public ShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe)
+    {
+        output = result.copy();
+        this.research = research;
+        this.aspects = aspects;
+        for (Object in : recipe)
+        {
+            if (in instanceof ItemStack)
+            {
+                input.add(((ItemStack)in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                input.add(new ItemStack((Item)in));
+            }
+            else if (in instanceof Block)
+            {
+                input.add(new ItemStack((Block)in));
+            }
+            else if (in instanceof String)
+            {
+                input.add(OreDictionary.getOres((String)in));
+            }
+            else
+            {
+                String ret = "Invalid shapeless ore recipe: ";
+                for (Object tmp :  recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+    }
+
+    @Override
+    public int getRecipeSize(){ return input.size(); }
+
+    @Override
+    public ItemStack getRecipeOutput(){ return output; }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory var1){ return output.copy(); }
+
+    @Override
+    public boolean matches(IInventory var1, World world, EntityPlayer player)
+    {
+    	if (research.length()>0 && !ThaumcraftApiHelper.isResearchComplete(player.getCommandSenderName(), research)) {
+    		return false;
+    	}
+    	
+        ArrayList required = new ArrayList(input);
+        
+        for (int x = 0; x < 9; x++)
+        {
+            ItemStack slot = var1.getStackInSlot(x);
+
+            if (slot != null)
+            {
+                boolean inRecipe = false;
+                Iterator req = required.iterator();
+
+                while (req.hasNext())
+                {
+                    boolean match = false;
+
+                    Object next = req.next();
+
+                    if (next instanceof ItemStack)
+                    {
+                        match = checkItemEquals((ItemStack)next, slot);
+                    }
+                    else if (next instanceof ArrayList)
+                    {
+                        for (ItemStack item : (ArrayList<ItemStack>)next)
+                        {
+                            match = match || checkItemEquals(item, slot);
+                        }
+                    }
+
+                    if (match)
+                    {
+                        inRecipe = true;
+                        required.remove(next);
+                        break;
+                    }
+                }
+
+                if (!inRecipe)
+                {
+                    return false;
+                }
+            }
+        }
+        
+        return required.isEmpty();
+    }
+
+    private boolean checkItemEquals(ItemStack target, ItemStack input)
+    {
+        if (input == null && target != null || input != null && target == null)
+        {
+            return false;
+        }
+        return (target.getItem() == input.getItem() && 
+        		(!target.hasTagCompound() || ThaumcraftApiHelper.areItemStackTagsEqualForCrafting(input,target)) &&
+        		(target.getItemDamage() == OreDictionary.WILDCARD_VALUE|| target.getItemDamage() == input.getItemDamage()));
+    }
+
+    /**
+     * Returns the input for this recipe, any mod accessing this value should never
+     * manipulate the values in this array as it will effect the recipe itself.
+     * @return The recipes input vales.
+     */
+    public ArrayList getInput()
+    {
+        return this.input;
+    }
+    
+    @Override		
+	public AspectList getAspects() {
+		return aspects;
+	}
+    
+    @Override		
+	public AspectList getAspects(IInventory inv) {
+		return aspects;
+	}
+	
+	@Override
+	public String getResearch() {
+		return research;
+	}
+}

--- a/src/api/java/thaumcraft/api/damagesource/DamageSourceIndirectThaumcraftEntity.java
+++ b/src/api/java/thaumcraft/api/damagesource/DamageSourceIndirectThaumcraftEntity.java
@@ -1,0 +1,32 @@
+package thaumcraft.api.damagesource;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EntityDamageSourceIndirect;
+
+public class DamageSourceIndirectThaumcraftEntity extends EntityDamageSourceIndirect {
+
+	private boolean fireDamage;
+	private float hungerDamage;
+	private boolean isUnblockable;
+
+
+	public DamageSourceIndirectThaumcraftEntity(String par1Str,
+			Entity par2Entity, Entity par3Entity) {
+		super(par1Str, par2Entity, par3Entity);
+	}
+
+	
+	public DamageSource setFireDamage()
+    {
+        this.fireDamage = true;
+        return this;
+    }
+	
+	public DamageSource setDamageBypassesArmor()
+    {
+        this.isUnblockable = true;
+        this.hungerDamage = 0.0F;
+        return this;
+    }
+}

--- a/src/api/java/thaumcraft/api/damagesource/DamageSourceThaumcraft.java
+++ b/src/api/java/thaumcraft/api/damagesource/DamageSourceThaumcraft.java
@@ -1,0 +1,47 @@
+package thaumcraft.api.damagesource;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EntityDamageSource;
+
+public class DamageSourceThaumcraft extends DamageSource
+{
+    
+	public static DamageSource taint = new DamageSourceThaumcraft("taint").setDamageBypassesArmor().setMagicDamage();
+	public static DamageSource tentacle = new DamageSourceThaumcraft("tentacle");
+	public static DamageSource swarm = new DamageSourceThaumcraft("swarm");
+	public static DamageSource dissolve = new DamageSourceThaumcraft("dissolve").setDamageBypassesArmor();
+	
+    protected DamageSourceThaumcraft(String par1Str) {
+		super(par1Str);
+	}
+    
+	/** This kind of damage can be blocked or not. */
+    private boolean isUnblockable = false;
+    private boolean isDamageAllowedInCreativeMode = false;
+    private float hungerDamage = 0.3F;
+
+    /** This kind of damage is based on fire or not. */
+    private boolean fireDamage;
+
+    /** This kind of damage is based on a projectile or not. */
+    private boolean projectile;
+
+    /**
+     * Whether this damage source will have its damage amount scaled based on the current difficulty.
+     */
+    private boolean difficultyScaled;
+    private boolean magicDamage = false;
+    private boolean explosion = false;
+    
+    public static DamageSource causeSwarmDamage(EntityLivingBase par0EntityLiving)
+    {
+        return new EntityDamageSource("swarm", par0EntityLiving);
+    }
+
+    public static DamageSource causeTentacleDamage(EntityLivingBase par0EntityLiving)
+    {
+        return new EntityDamageSource("tentacle", par0EntityLiving);
+    }
+    
+}

--- a/src/api/java/thaumcraft/api/entities/IEldritchMob.java
+++ b/src/api/java/thaumcraft/api/entities/IEldritchMob.java
@@ -1,0 +1,5 @@
+package thaumcraft.api.entities;
+
+public interface IEldritchMob {
+
+}

--- a/src/api/java/thaumcraft/api/entities/ITaintedMob.java
+++ b/src/api/java/thaumcraft/api/entities/ITaintedMob.java
@@ -1,0 +1,5 @@
+package thaumcraft.api.entities;
+
+public interface ITaintedMob {
+
+}

--- a/src/api/java/thaumcraft/api/internal/DummyInternalMethodHandler.java
+++ b/src/api/java/thaumcraft/api/internal/DummyInternalMethodHandler.java
@@ -1,0 +1,78 @@
+package thaumcraft.api.internal;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public class DummyInternalMethodHandler implements IInternalMethodHandler {
+
+	@Override
+	public void generateVisEffect(int dim, int x, int y, int z, int x2, int y2,	int z2, int color) {
+		
+	}
+
+	@Override
+	public boolean isResearchComplete(String username, String researchkey) {
+		return false;
+	}
+	
+	@Override
+	public boolean hasDiscoveredAspect(String username, Aspect aspect) {
+		return false;
+	}
+	
+	@Override
+	public AspectList getDiscoveredAspects(String username) {
+		return null;
+	}
+
+	@Override
+	public ItemStack getStackInRowAndColumn(Object instance, int row, int column) {
+		return null;
+	}
+
+	@Override
+	public AspectList getObjectAspects(ItemStack is) {
+		return null;
+	}
+
+	@Override
+	public AspectList getBonusObjectTags(ItemStack is, AspectList ot) {
+		return null;
+	}
+
+	@Override
+	public AspectList generateTags(Item item, int meta) {
+		return null;
+	}
+
+	@Override
+	public boolean consumeVisFromWand(ItemStack wand, EntityPlayer player,
+			AspectList cost, boolean doit, boolean crafting) {
+		return false;
+	}
+
+	@Override
+	public boolean consumeVisFromWandCrafting(ItemStack wand,
+			EntityPlayer player, AspectList cost, boolean doit) {
+		return false;
+	}
+
+	@Override
+	public boolean consumeVisFromInventory(EntityPlayer player, AspectList cost) {
+		return false;
+	}
+
+	@Override
+	public void addWarpToPlayer(EntityPlayer player, int amount, boolean temporary) {
+	}
+
+	@Override
+	public void addStickyWarpToPlayer(EntityPlayer player, int amount) {
+	}
+
+	
+	
+}

--- a/src/api/java/thaumcraft/api/internal/IInternalMethodHandler.java
+++ b/src/api/java/thaumcraft/api/internal/IInternalMethodHandler.java
@@ -1,0 +1,25 @@
+package thaumcraft.api.internal;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public interface IInternalMethodHandler {
+
+	public void generateVisEffect(int dim, int x, int y, int z, int x2, int y2, int z2, int color);
+	public boolean isResearchComplete(String username, String researchkey);
+	public ItemStack getStackInRowAndColumn(Object instance, int row, int column);
+	public AspectList getObjectAspects(ItemStack is);
+	public AspectList getBonusObjectTags(ItemStack is,AspectList ot);
+	public AspectList generateTags(Item item, int meta);
+	public boolean consumeVisFromWand(ItemStack wand, EntityPlayer player, AspectList cost, boolean doit, boolean crafting);
+	public boolean consumeVisFromWandCrafting(ItemStack wand,EntityPlayer player, AspectList cost, boolean doit);
+	public boolean consumeVisFromInventory(EntityPlayer player, AspectList cost);
+	public void addWarpToPlayer(EntityPlayer player, int amount,boolean temporary);
+	public void addStickyWarpToPlayer(EntityPlayer player, int amount);
+	public boolean hasDiscoveredAspect(String username, Aspect aspect);
+	public AspectList getDiscoveredAspects(String username);
+	
+}

--- a/src/api/java/thaumcraft/api/internal/WeightedRandomLoot.java
+++ b/src/api/java/thaumcraft/api/internal/WeightedRandomLoot.java
@@ -1,0 +1,24 @@
+package thaumcraft.api.internal;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.WeightedRandom;
+
+
+public class WeightedRandomLoot extends WeightedRandom.Item {
+	
+	/** The Item/Block ID to generate in the bag. */
+    public ItemStack item;
+
+    public WeightedRandomLoot(ItemStack stack, int weight)
+    {
+        super(weight);
+        this.item = stack;
+    }
+    
+    public static ArrayList<WeightedRandomLoot> lootBagCommon = new ArrayList<WeightedRandomLoot>();
+    public static ArrayList<WeightedRandomLoot> lootBagUncommon = new ArrayList<WeightedRandomLoot>();
+    public static ArrayList<WeightedRandomLoot> lootBagRare = new ArrayList<WeightedRandomLoot>();
+    
+}

--- a/src/api/java/thaumcraft/api/nodes/INode.java
+++ b/src/api/java/thaumcraft/api/nodes/INode.java
@@ -1,0 +1,53 @@
+package thaumcraft.api.nodes;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.IAspectContainer;
+
+public interface INode extends IAspectContainer {
+
+	/**
+	 * Unique identifier to distinguish nodes. Normal node id's are based on world id and coordinates
+	 * @return
+	 */
+	public String getId();
+	
+	public AspectList getAspectsBase();
+	
+	/**
+	 * Return the type of node
+	 * @return
+	 */
+	public NodeType getNodeType();
+
+	/**
+	 * Set the type of node
+	 * @return
+	 */
+	public void setNodeType(NodeType nodeType);
+
+	/**
+	 * Set the node modifier
+	 * @return
+	 */
+	public void setNodeModifier(NodeModifier nodeModifier);
+	
+	/**
+	 * Return the node modifier
+	 * @return
+	 */
+	public NodeModifier getNodeModifier();
+		
+	/**
+	 * Return the maximum capacity of each aspect the node can hold
+	 * @return
+	 */
+	public int getNodeVisBase(Aspect aspect);
+
+	/**
+	 * Set the maximum capacity of each aspect the node can hold
+	 * @return
+	 */
+	public void setNodeVisBase(Aspect aspect, short nodeVisBase);
+	
+}

--- a/src/api/java/thaumcraft/api/nodes/IRevealer.java
+++ b/src/api/java/thaumcraft/api/nodes/IRevealer.java
@@ -1,0 +1,22 @@
+package thaumcraft.api.nodes;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * Equipped head slot items that extend this class will make nodes visible in world.
+ *
+ */
+
+public interface IRevealer {
+	
+	/*
+	 * If this method returns true the nodes will be visible.
+	 */
+	public boolean showNodes(ItemStack itemstack, EntityLivingBase player);
+	
+
+}

--- a/src/api/java/thaumcraft/api/nodes/NodeModifier.java
+++ b/src/api/java/thaumcraft/api/nodes/NodeModifier.java
@@ -1,0 +1,6 @@
+package thaumcraft.api.nodes;
+
+public enum NodeModifier
+{
+    BRIGHT, PALE, FADING
+}

--- a/src/api/java/thaumcraft/api/nodes/NodeType.java
+++ b/src/api/java/thaumcraft/api/nodes/NodeType.java
@@ -1,0 +1,6 @@
+package thaumcraft.api.nodes;
+
+public enum NodeType
+{
+    NORMAL, UNSTABLE, DARK, TAINTED, HUNGRY, PURE
+}

--- a/src/api/java/thaumcraft/api/package-info.java
+++ b/src/api/java/thaumcraft/api/package-info.java
@@ -1,0 +1,4 @@
+@API(owner = "Thaumcraft", apiVersion = "4.2.2.0", provides = "Thaumcraft|API")
+package thaumcraft.api;
+
+import cpw.mods.fml.common.API;

--- a/src/api/java/thaumcraft/api/potions/PotionFluxTaint.java
+++ b/src/api/java/thaumcraft/api/potions/PotionFluxTaint.java
@@ -1,0 +1,67 @@
+package thaumcraft.api.potions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.ResourceLocation;
+import thaumcraft.api.damagesource.DamageSourceThaumcraft;
+import thaumcraft.api.entities.ITaintedMob;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class PotionFluxTaint extends Potion
+{
+    public static PotionFluxTaint instance = null; // will be instantiated at runtime
+    private int statusIconIndex = -1;
+    
+    public PotionFluxTaint(int par1, boolean par2, int par3)
+    {
+    	super(par1,par2,par3);
+    	setIconIndex(0, 0);
+    }
+    
+    public static void init()
+    {
+    	instance.setPotionName("potion.fluxtaint");
+    	instance.setIconIndex(3, 1);
+    	instance.setEffectiveness(0.25D);
+    }
+    
+	@Override
+	public boolean isBadEffect() {
+		return true;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public int getStatusIconIndex() {
+		Minecraft.getMinecraft().renderEngine.bindTexture(rl);
+		return super.getStatusIconIndex();
+	}
+	
+	static final ResourceLocation rl = new ResourceLocation("thaumcraft","textures/misc/potions.png");
+	
+	@Override
+	public void performEffect(EntityLivingBase target, int par2) {
+		if (target instanceof ITaintedMob) {
+			target.heal(1);
+		} else
+		if (!target.isEntityUndead() && !(target instanceof EntityPlayer))
+        {
+			target.attackEntityFrom(DamageSourceThaumcraft.taint, 1);
+        } 
+		else
+		if (!target.isEntityUndead() && (target.getMaxHealth() > 1 || (target instanceof EntityPlayer)))
+        {
+			target.attackEntityFrom(DamageSourceThaumcraft.taint, 1);
+        } 
+	}
+    
+	public boolean isReady(int par1, int par2)
+    {
+		int k = 40 >> par2;
+        return k > 0 ? par1 % k == 0 : true;
+    }
+    
+}

--- a/src/api/java/thaumcraft/api/potions/PotionVisExhaust.java
+++ b/src/api/java/thaumcraft/api/potions/PotionVisExhaust.java
@@ -1,0 +1,48 @@
+package thaumcraft.api.potions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.ResourceLocation;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class PotionVisExhaust extends Potion
+{
+    public static PotionVisExhaust instance = null; // will be instantiated at runtime
+    private int statusIconIndex = -1;
+    
+    public PotionVisExhaust(int par1, boolean par2, int par3)
+    {
+    	super(par1,par2,par3);
+    	setIconIndex(0, 0);
+    }
+    
+    public static void init()
+    {
+    	instance.setPotionName("potion.visexhaust");
+    	instance.setIconIndex(5, 1);
+    	instance.setEffectiveness(0.25D);
+    }
+    
+	@Override
+	public boolean isBadEffect() {
+		return true;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public int getStatusIconIndex() {
+		Minecraft.getMinecraft().renderEngine.bindTexture(rl);
+		return super.getStatusIconIndex();
+	}
+	
+	static final ResourceLocation rl = new ResourceLocation("thaumcraft","textures/misc/potions.png");
+	
+	@Override
+	public void performEffect(EntityLivingBase target, int par2) {
+		
+	}
+    
+    
+}

--- a/src/api/java/thaumcraft/api/research/IScanEventHandler.java
+++ b/src/api/java/thaumcraft/api/research/IScanEventHandler.java
@@ -1,0 +1,9 @@
+package thaumcraft.api.research;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IScanEventHandler {
+	ScanResult scanPhenomena(ItemStack stack, World world, EntityPlayer player);
+}

--- a/src/api/java/thaumcraft/api/research/ResearchCategories.java
+++ b/src/api/java/thaumcraft/api/research/ResearchCategories.java
@@ -1,0 +1,101 @@
+package thaumcraft.api.research;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+
+import org.apache.logging.log4j.Level;
+
+import cpw.mods.fml.common.FMLLog;
+
+public class ResearchCategories {
+	
+	//Research
+	public static LinkedHashMap <String, ResearchCategoryList> researchCategories = new LinkedHashMap <String,ResearchCategoryList>();
+	
+	/**
+	 * @param key
+	 * @return the research item linked to this key
+	 */
+	public static ResearchCategoryList getResearchList(String key) {
+		return researchCategories.get(key);
+	}
+	
+	/**
+	 * @param key
+	 * @return the name of the research category linked to this key. 
+	 * Must be stored as localization information in the LanguageRegistry.
+	 */
+	public static String getCategoryName(String key) {
+		return StatCollector.translateToLocal("tc.research_category."+key);
+	}
+	
+	/**
+	 * @param key the research key
+	 * @return the ResearchItem object. 
+	 */
+	public static ResearchItem getResearch(String key) {
+		Collection rc = researchCategories.values();
+		for (Object cat:rc) {
+			Collection rl = ((ResearchCategoryList)cat).research.values();
+			for (Object ri:rl) {
+				if ((((ResearchItem)ri).key).equals(key)) return (ResearchItem)ri;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * This should only be done at the PostInit stage
+	 * @param key the key used for this category
+	 * @param icon the icon to be used for the research category tab
+	 * @param background the resource location of the background image to use for this category
+	 * @return the name of the research linked to this key
+	 */
+	public static void registerCategory(String key, ResourceLocation icon, ResourceLocation background) {
+		if (getResearchList(key)==null) {
+			ResearchCategoryList rl = new ResearchCategoryList(icon, background);
+			researchCategories.put(key, rl);
+		}
+	}
+	
+	public static void addResearch(ResearchItem ri) {
+		ResearchCategoryList rl = getResearchList(ri.category);
+		if (rl!=null && !rl.research.containsKey(ri.key)) {
+			
+			if (!ri.isVirtual()) {
+				for (ResearchItem rr:rl.research.values()) {
+					if (rr.displayColumn == ri.displayColumn && rr.displayRow == ri.displayRow) {
+						FMLLog.log(Level.FATAL, "[Thaumcraft] Research ["+ri.getName()+"] not added as it overlaps with existing research ["+rr.getName()+"]");
+						return;
+					}
+				}
+			}
+			
+			
+			rl.research.put(ri.key, ri);
+			
+			if (ri.displayColumn < rl.minDisplayColumn) 
+	        {
+	            rl.minDisplayColumn = ri.displayColumn;
+	        }
+
+	        if (ri.displayRow < rl.minDisplayRow)
+	        {
+	            rl.minDisplayRow = ri.displayRow;
+	        }
+
+	        if (ri.displayColumn > rl.maxDisplayColumn)
+	        {
+	            rl.maxDisplayColumn = ri.displayColumn;
+	        }
+
+	        if (ri.displayRow > rl.maxDisplayRow)
+	        {
+	            rl.maxDisplayRow = ri.displayRow;
+	        }
+	        		}
+	}
+}

--- a/src/api/java/thaumcraft/api/research/ResearchCategoryList.java
+++ b/src/api/java/thaumcraft/api/research/ResearchCategoryList.java
@@ -1,0 +1,37 @@
+package thaumcraft.api.research;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.util.ResourceLocation;
+
+public class ResearchCategoryList {
+	
+	/** Is the smallest column used on the GUI. */
+    public int minDisplayColumn;
+
+    /** Is the smallest row used on the GUI. */
+    public int minDisplayRow;
+
+    /** Is the biggest column used on the GUI. */
+    public int maxDisplayColumn;
+
+    /** Is the biggest row used on the GUI. */
+    public int maxDisplayRow;
+    
+    /** display variables **/
+    public ResourceLocation icon;
+    public ResourceLocation background;
+	
+	public ResearchCategoryList(ResourceLocation icon, ResourceLocation background) {
+		this.icon = icon;
+		this.background = background;
+	}
+
+	//Research
+	public Map<String, ResearchItem> research = new HashMap<String,ResearchItem>();
+		
+		
+	
+	
+}

--- a/src/api/java/thaumcraft/api/research/ResearchItem.java
+++ b/src/api/java/thaumcraft/api/research/ResearchItem.java
@@ -1,0 +1,369 @@
+package thaumcraft.api.research;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public class ResearchItem 
+{
+	/**
+	 * A short string used as a key for this research. Must be unique
+	 */
+	public final String key;
+	
+	/**
+	 * A short string used as a reference to the research category to which this must be added.
+	 */
+	public final String category;
+
+	/**
+	 * The aspect tags and their values required to complete this research
+	 */
+	public final AspectList tags;
+	
+    /**
+     * This links to any research that needs to be completed before this research can be discovered or learnt.
+     */
+    public String[] parents = null;
+    
+    /**
+     * Like parent above, but a line will not be displayed in the thaumonomicon linking them. Just used to prevent clutter.
+     */
+    public String[] parentsHidden = null;
+    /**
+     * any research linked to this that will be unlocked automatically when this research is complete
+     */
+    public String[] siblings = null;
+	
+    /**
+     * the horizontal position of the research icon
+     */
+    public final int displayColumn;
+
+    /**
+     * the vertical position of the research icon
+     */
+    public final int displayRow;
+    
+    /**
+     * the icon to be used for this research 
+     */
+    public final ItemStack icon_item;
+    
+    /**
+     * the icon to be used for this research 
+     */
+    public final ResourceLocation icon_resource;
+    
+    /**
+     * How large the research grid is. Valid values are 1 to 3.
+     */
+    private int complexity;
+
+    /**
+     * Special research has a spiky border. Used for important research milestones.
+     */
+    private boolean isSpecial;
+    
+    /**
+     * Research that can be directly purchased with RP in normal research difficulty.
+     */
+    private boolean isSecondary;
+    
+	/**
+     * This indicates if the research should use a circular icon border. Usually used for "passive" research 
+     * that doesn't have recipes and grants passive effects, or that unlock automatically.
+     */
+    private boolean isRound;
+    
+    /**
+     * Stub research cannot be discovered by normal means, but can be unlocked via the sibling system.
+     */
+    private boolean isStub;
+    
+    /**
+     * This indicated that the research is completely hidden and cannot be discovered by any 
+     * player-controlled means. The recipes will never show up in the thaumonomicon.
+     * Usually used to unlock "hidden" recipes via sibling unlocking, like 
+     * the various cap and rod combos for wands.
+     */
+    private boolean isVirtual;    
+    
+    
+    
+    /**
+     * Concealed research does not display in the thaumonomicon until parent researches are discovered.
+     */
+    private boolean isConcealed;
+    
+    /**
+     * Hidden research can only be discovered via scanning or knowledge fragments 
+     */
+    private boolean isHidden;
+    
+    /**
+     * This is the same as isHidden, except it cannot be discovered with knowledge fragments, only scanning.  
+     */
+    private boolean isLost;
+    
+    /**
+     * These research items will automatically unlock for all players on game start
+     */
+    private boolean isAutoUnlock;
+    
+    /**
+     * Scanning these items will have a chance of revealing hidden knowledge in the thaumonomicon
+     */
+    private ItemStack[] itemTriggers;
+    
+    /**
+     * Scanning these entities will have a chance of revealing hidden knowledge in the thaumonomicon
+     */
+    private String[] entityTriggers;
+    
+    /**
+     * Scanning things with these aspects will have a chance of revealing hidden knowledge in the thaumonomicon
+     */
+    private Aspect[] aspectTriggers;
+
+	private ResearchPage[] pages = null;
+	
+	public ResearchItem(String key, String category)
+    {
+    	this.key = key;
+    	this.category = category;
+    	this.tags = new AspectList();    	
+        this.icon_resource = null;
+        this.icon_item = null;
+        this.displayColumn = 0;
+        this.displayRow = 0;
+        this.setVirtual();
+        
+    }
+    
+    public ResearchItem(String key, String category, AspectList tags, int col, int row, int complex, ResourceLocation icon)
+    {
+    	this.key = key;
+    	this.category = category;
+    	this.tags = tags;    	
+        this.icon_resource = icon;
+        this.icon_item = null;
+        this.displayColumn = col;
+        this.displayRow = row;
+        this.complexity = complex;
+        if (complexity < 1) this.complexity = 1;
+        if (complexity > 3) this.complexity = 3;
+    }
+    
+    public ResearchItem(String key, String category, AspectList tags, int col, int row, int complex, ItemStack icon)
+    {
+    	this.key = key;
+    	this.category = category;
+    	this.tags = tags;    	
+        this.icon_item = icon;
+        this.icon_resource = null;
+        this.displayColumn = col;
+        this.displayRow = row;
+        this.complexity = complex;
+        if (complexity < 1) this.complexity = 1;
+        if (complexity > 3) this.complexity = 3;
+    }
+
+    public ResearchItem setSpecial()
+    {
+        this.isSpecial = true;
+        return this;
+    }
+    
+    public ResearchItem setStub()
+    {
+        this.isStub = true;
+        return this;
+    }
+    
+    public ResearchItem setLost()
+    {
+        this.isLost = true;
+        return this;
+    }
+    
+    public ResearchItem setConcealed()
+    {
+        this.isConcealed = true;
+        return this;
+    }
+    
+    public ResearchItem setHidden()
+    {
+        this.isHidden = true;
+        return this;
+    }
+    
+    public ResearchItem setVirtual()
+    {
+        this.isVirtual = true;
+        return this;
+    }
+    
+    public ResearchItem setParents(String... par)
+    {
+        this.parents = par;
+        return this;
+    }
+    
+    
+
+	public ResearchItem setParentsHidden(String... par)
+    {
+        this.parentsHidden = par;
+        return this;
+    }
+    
+    public ResearchItem setSiblings(String... sib)
+    {
+        this.siblings = sib;
+        return this;
+    }
+    
+    public ResearchItem setPages(ResearchPage... par)
+    {
+        this.pages = par;
+        return this;
+    }
+    
+    public ResearchPage[] getPages() {
+		return pages;
+	}
+    
+    public ResearchItem setItemTriggers(ItemStack... par)
+    {
+        this.itemTriggers = par;
+        return this;
+    }
+    
+    public ResearchItem setEntityTriggers(String... par)
+    {
+        this.entityTriggers = par;
+        return this;
+    }
+    
+    public ResearchItem setAspectTriggers(Aspect... par)
+    {
+        this.aspectTriggers = par;
+        return this;
+    }
+
+    public ItemStack[] getItemTriggers() {
+		return itemTriggers;
+	}
+
+	public String[] getEntityTriggers() {
+		return entityTriggers;
+	}
+	
+	public Aspect[] getAspectTriggers() {
+		return aspectTriggers;
+	}
+
+	public ResearchItem registerResearchItem()
+    {
+        ResearchCategories.addResearch(this);
+        return this;
+    }
+
+    public String getName()
+    {
+    	return StatCollector.translateToLocal("tc.research_name."+key);
+    }
+    
+    public String getText()
+    {
+    	return StatCollector.translateToLocal("tc.research_text."+key);
+    }
+
+    public boolean isSpecial()
+    {
+        return this.isSpecial;
+    }
+    
+    public boolean isStub()
+    {
+        return this.isStub;
+    }
+        
+    public boolean isLost()
+    {
+        return this.isLost;
+    }
+    
+    public boolean isConcealed()
+    {
+        return this.isConcealed;
+    }
+    
+    public boolean isHidden()
+    {
+        return this.isHidden;
+    }
+    
+    public boolean isVirtual()
+    {
+        return this.isVirtual;
+    }
+    
+    public boolean isAutoUnlock() {
+		return isAutoUnlock;
+	}
+	
+	public ResearchItem setAutoUnlock()
+    {
+        this.isAutoUnlock = true;
+        return this;
+    }
+	
+	public boolean isRound() {
+		return isRound;
+	}
+
+	public ResearchItem setRound() {
+		this.isRound = true;
+		return this;
+	}
+	
+	public boolean isSecondary() {
+		return isSecondary;
+	}
+
+	public ResearchItem setSecondary() {
+		this.isSecondary = true;
+		return this;
+	}
+
+	public int getComplexity() {
+		return complexity;
+	}
+
+	public ResearchItem setComplexity(int complexity) {
+		this.complexity = complexity;
+		return this;
+	}
+
+	/**
+	 * @return the aspect aspects ordinal with the highest value. Used to determine scroll color and similar things
+	 */
+	public Aspect getResearchPrimaryTag() {
+		Aspect aspect=null;
+		int highest=0;
+		if (tags!=null)
+		for (Aspect tag:tags.getAspects()) {
+			if (tags.getAmount(tag)>highest) {
+				aspect=tag;
+				highest=tags.getAmount(tag);
+			};
+		}
+		return aspect;
+	}
+	
+}

--- a/src/api/java/thaumcraft/api/research/ResearchPage.java
+++ b/src/api/java/thaumcraft/api/research/ResearchPage.java
@@ -1,0 +1,193 @@
+package thaumcraft.api.research;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.api.crafting.InfusionEnchantmentRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+
+public class ResearchPage {
+	public static enum PageType
+    {
+        TEXT,
+        TEXT_CONCEALED,
+        IMAGE,
+        CRUCIBLE_CRAFTING,
+        ARCANE_CRAFTING,
+        ASPECTS,
+        NORMAL_CRAFTING,
+        INFUSION_CRAFTING,
+        COMPOUND_CRAFTING,
+        INFUSION_ENCHANTMENT,
+        SMELTING
+    }
+	
+	public PageType type = PageType.TEXT;
+	
+	public String text=null;
+	public String research=null;
+	public ResourceLocation image=null;
+	public AspectList aspects=null;
+	public Object recipe=null;
+	public ItemStack recipeOutput=null;
+	
+	/**
+	 * @param text this can (but does not have to) be a reference to a localization variable, not the actual text.
+	 */
+	public ResearchPage(String text) {
+		this.type = PageType.TEXT;
+		this.text = text;
+	}
+	
+	/**
+	 * @param research this page will only be displayed if the player has discovered this research
+	 * @param text this can (but does not have to) be a reference to a localization variable, not the actual text.
+	 */
+	public ResearchPage(String research, String text) {
+		this.type = PageType.TEXT_CONCEALED;
+		this.research = research;
+		this.text = text;
+	}
+	
+	/**
+	 * @param recipe a vanilla crafting recipe.
+	 */
+	public ResearchPage(IRecipe recipe) {
+		this.type = PageType.NORMAL_CRAFTING;
+		this.recipe = recipe;
+		this.recipeOutput = recipe.getRecipeOutput();
+	}
+	
+	/**
+	 * @param recipe a collection of vanilla crafting recipes.
+	 */
+	public ResearchPage(IRecipe[] recipe) {
+		this.type = PageType.NORMAL_CRAFTING;
+		this.recipe = recipe;
+	}
+	
+	/**
+	 * @param recipe a collection of arcane crafting recipes.
+	 */
+	public ResearchPage(IArcaneRecipe[] recipe) {
+		this.type = PageType.ARCANE_CRAFTING;
+		this.recipe = recipe;
+	}
+	
+	/**
+	 * @param recipe a collection of arcane crafting recipes.
+	 */
+	public ResearchPage(CrucibleRecipe[] recipe) {
+		this.type = PageType.CRUCIBLE_CRAFTING;
+		this.recipe = recipe;
+	}
+	
+	/**
+	 * @param recipe a collection of infusion crafting recipes.
+	 */
+	public ResearchPage(InfusionRecipe[] recipe) {
+		this.type = PageType.INFUSION_CRAFTING;
+		this.recipe = recipe;
+	}
+	
+	/**
+	 * @param recipe a compound crafting recipe.
+	 */
+	public ResearchPage(List recipe) {
+		this.type = PageType.COMPOUND_CRAFTING;
+		this.recipe = recipe;
+	}
+	
+	/**
+	 * @param recipe an arcane worktable crafting recipe.
+	 */
+	public ResearchPage(IArcaneRecipe recipe) {
+		this.type = PageType.ARCANE_CRAFTING;
+		this.recipe = recipe;
+		this.recipeOutput = recipe.getRecipeOutput();
+	}
+	
+	/**
+	 * @param recipe an alchemy crafting recipe.
+	 */
+	public ResearchPage(CrucibleRecipe recipe) {
+		this.type = PageType.CRUCIBLE_CRAFTING;
+		this.recipe = recipe;
+		this.recipeOutput = recipe.getRecipeOutput();
+	}
+	
+	/**
+	 * @param recipe a furnace smelting crafting recipe.
+	 */
+	public ResearchPage(ItemStack input) {
+		this.type = PageType.SMELTING;
+		this.recipe = input;
+		this.recipeOutput = FurnaceRecipes.smelting().getSmeltingResult(input);
+	}
+	
+	/**
+	 * @param recipe an infusion crafting recipe.
+	 */
+	public ResearchPage(InfusionRecipe recipe) {
+		this.type = PageType.INFUSION_CRAFTING;
+		this.recipe = recipe;
+		if (recipe.getRecipeOutput() instanceof ItemStack) {
+			this.recipeOutput = (ItemStack) recipe.getRecipeOutput();
+		} else {
+			this.recipeOutput = recipe.getRecipeInput();
+		}
+	}
+	
+	/**
+	 * @param recipe an infusion crafting recipe.
+	 */
+	public ResearchPage(InfusionEnchantmentRecipe recipe) {
+		this.type = PageType.INFUSION_ENCHANTMENT;
+		this.recipe = recipe;
+//		if (recipe.recipeOutput instanceof ItemStack) {
+//			this.recipeOutput = (ItemStack) recipe.recipeOutput;
+//		} else {
+//			this.recipeOutput = recipe.recipeInput;
+//		}
+	}
+	
+	/**
+	 * @param image
+	 * @param caption this can (but does not have to) be a reference to a localization variable, not the actual text.
+	 */
+	public ResearchPage(ResourceLocation image, String caption) {
+		this.type = PageType.IMAGE;
+		this.image = image;
+		this.text = caption;
+	}
+	
+	/**
+	 * This function should really not be called directly - used internally
+	 */
+	public ResearchPage(AspectList as) {
+		this.type = PageType.ASPECTS;
+		this.aspects = as;
+	}
+	
+	/**
+	 * returns a localized text of the text field (if one exists). Returns the text field itself otherwise.
+	 * @return
+	 */
+	public String getTranslatedText() {
+		String ret="";
+		if (text != null) {
+			ret = StatCollector.translateToLocal(text);
+			if (ret.isEmpty()) ret = text;
+		}
+		return ret;
+	}
+	
+	
+}

--- a/src/api/java/thaumcraft/api/research/ScanResult.java
+++ b/src/api/java/thaumcraft/api/research/ScanResult.java
@@ -1,0 +1,39 @@
+package thaumcraft.api.research;
+
+import net.minecraft.entity.Entity;
+
+public class ScanResult {
+	public byte type = 0;   //1=blocks,2=entities,3=phenomena
+	public int id;
+	public int meta;
+	public Entity entity;
+	public String phenomena;
+
+	public ScanResult(byte type, int blockId, int blockMeta, Entity entity,
+			String phenomena) {
+		super();
+		this.type = type;
+		this.id = blockId;
+		this.meta = blockMeta;		
+		this.entity = entity;
+		this.phenomena = phenomena;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ScanResult) {
+			ScanResult sr = (ScanResult) obj;
+			if (type != sr.type)
+				return false;
+			if (type == 1
+					&& (id != sr.id || meta != sr.meta))
+				return false;
+			if (type == 2 && entity.getEntityId() != sr.entity.getEntityId())
+				return false;
+			if (type == 3 && !phenomena.equals(sr.phenomena))
+				return false;
+		}
+		return true;
+	}
+
+}

--- a/src/api/java/thaumcraft/api/visnet/TileVisNode.java
+++ b/src/api/java/thaumcraft/api/visnet/TileVisNode.java
@@ -1,0 +1,188 @@
+package thaumcraft.api.visnet;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.WorldCoordinates;
+import thaumcraft.api.aspects.Aspect;
+
+/**
+ * @author Azanor
+ * 
+ * The tile entity used by nodes in the vis energy network. A node is either a source (like an aura node),
+ * a transport relay or vis receiver (like the infernal furnace).
+ *
+ */
+public abstract class TileVisNode extends TileThaumcraft {
+	
+	WeakReference<TileVisNode> parent = null;
+	ArrayList<WeakReference<TileVisNode>> children = new ArrayList<WeakReference<TileVisNode>>();
+	
+	/**
+	 * @return the WorldCoordinates location of where this node is located
+	 */
+	public WorldCoordinates getLocation() {
+		return new WorldCoordinates(this);
+	}
+	
+	/**
+	 * @return the number of blocks away this node will check for parent nodes to connect to. 
+	 */
+	public abstract int getRange();
+	
+	/**
+	 * @return true if this is the source or root node of the vis network. 
+	 */
+	public abstract boolean isSource();
+		
+	/**
+	 * This method should never be called directly. Use VisNetHandler.drainVis() instead
+	 * @param aspect what aspect to drain
+	 * @param vis how much to drain
+	 * @return how much was actually drained
+	 */
+	public int consumeVis(Aspect aspect, int vis) {
+		if (VisNetHandler.isNodeValid(getParent())) {
+			int out = getParent().get().consumeVis(aspect, vis);
+			if (out>0) {
+				triggerConsumeEffect(aspect);
+			}
+			return out;
+		}
+		return 0;
+	}
+	
+	public void removeThisNode() {
+		for (WeakReference<TileVisNode> n:getChildren()) {
+			if (n!=null && n.get()!=null) {
+				n.get().removeThisNode();
+			}
+		}	
+		
+		children = new ArrayList<WeakReference<TileVisNode>>();
+		if (VisNetHandler.isNodeValid(this.getParent())) {
+			this.getParent().get().nodeRefresh=true;
+		}
+		this.setParent(null);
+		this.parentChanged();
+		
+		if (this.isSource()) {
+			HashMap<WorldCoordinates, WeakReference<TileVisNode>> sourcelist = VisNetHandler.sources.get(worldObj.provider.dimensionId);
+			if (sourcelist==null) {
+				sourcelist = new HashMap<WorldCoordinates, WeakReference<TileVisNode>>();
+			}
+			sourcelist.remove(getLocation());
+			VisNetHandler.sources.put( worldObj.provider.dimensionId, sourcelist );
+		}
+		
+		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+	}
+	
+	
+
+	@Override
+	public void invalidate() {
+		removeThisNode();
+		super.invalidate();
+	}
+
+	public void triggerConsumeEffect(Aspect aspect) {	}
+
+	/**
+	 * @return
+	 */
+	public WeakReference<TileVisNode> getParent() {
+		return parent;
+	}
+	
+	/**
+	 * @return
+	 */
+	public WeakReference<TileVisNode> getRootSource() {
+		return VisNetHandler.isNodeValid(getParent()) ? 
+				getParent().get().getRootSource() : this.isSource() ?
+						new WeakReference(this) : null;
+	}
+	
+	/**
+	 * @param parent
+	 */
+	public void setParent(WeakReference<TileVisNode> parent) {
+		this.parent = parent;
+	}
+	
+	/**
+	 * @return
+	 */
+	public ArrayList<WeakReference<TileVisNode>> getChildren() {
+		return children;
+	}
+	
+	@Override
+	public boolean canUpdate() {
+		return true;
+	}
+	
+	protected int nodeCounter = 0;
+	private boolean nodeRegged = false;
+	public boolean nodeRefresh = false;
+
+	@Override
+	public void updateEntity() {
+				
+		if (!worldObj.isRemote && ((nodeCounter++) % 40==0 || nodeRefresh)) {
+			//check for changes
+			if (!nodeRefresh && children.size()>0) {
+				for (WeakReference<TileVisNode> n:children) {
+					if (n==null || n.get()==null || !VisNetHandler.canNodeBeSeen(this, n.get())) {
+						nodeRefresh=true;
+						break;
+					}
+				}			
+			}
+			
+			//refresh linked nodes
+			if (nodeRefresh) {
+				for (WeakReference<TileVisNode> n:children) {
+					if (n.get()!=null) {
+						n.get().nodeRefresh=true;
+					}
+				}
+				children.clear();
+				parent=null;
+			}
+			
+			//redo stuff
+			if (isSource() && !nodeRegged) {
+				VisNetHandler.addSource(getWorldObj(), this);
+				nodeRegged = true;
+			} else 
+			if (!isSource() && !VisNetHandler.isNodeValid(getParent())) {
+				setParent(VisNetHandler.addNode(getWorldObj(), this));				
+				nodeRefresh=true;
+			}
+			
+			if (nodeRefresh) {
+				worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+				parentChanged();
+			}
+			nodeRefresh=false;
+		}
+		
+	}
+	
+	public void parentChanged() { }
+	
+	/**
+	 * @return the type of shard this is attuned to:
+	 * none -1, air 0, fire 1, water 2, earth 3, order 4, entropy 5
+	 * Should return -1 for most implementations
+	 */
+	public byte getAttunement() {
+		return -1;
+	}
+		
+	
+}

--- a/src/api/java/thaumcraft/api/visnet/VisNetHandler.java
+++ b/src/api/java/thaumcraft/api/visnet/VisNetHandler.java
@@ -1,0 +1,282 @@
+package thaumcraft.api.visnet;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.MovingObjectPosition.MovingObjectType;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.ThaumcraftApiHelper;
+import thaumcraft.api.WorldCoordinates;
+import thaumcraft.api.aspects.Aspect;
+
+public class VisNetHandler {
+
+	// NODE DRAINING
+	/**
+	 * This method drains vis from a relay or source near the passed in
+	 * location. The amount received can be less than the amount requested so
+	 * take that into account.
+	 * 
+	 * @param world
+	 * @param x the x position of the draining block or entity
+	 * @param y the y position of the draining block or entity
+	 * @param z the z position of the draining block or entity
+	 * @param aspect what aspect to drain
+	 * @param amount how much to drain
+	 * @return how much was actually drained
+	 */
+	public static int drainVis(World world, int x, int y, int z, Aspect aspect, int amount) {
+
+		int drainedAmount = 0;
+
+		WorldCoordinates drainer = new WorldCoordinates(x, y, z,
+				world.provider.dimensionId);
+		if (!nearbyNodes.containsKey(drainer)) {
+			calculateNearbyNodes(world, x, y, z);
+		}
+
+		ArrayList<WeakReference<TileVisNode>> nodes = nearbyNodes.get(drainer);
+		if (nodes!=null && nodes.size()>0)
+		for (WeakReference<TileVisNode> noderef : nodes) {
+			
+			TileVisNode node = noderef.get();
+			
+			if (node == null) continue;
+
+			int a = node.consumeVis(aspect, amount);
+			drainedAmount += a;
+			amount -= a;
+			if (a>0) {
+				int color = Aspect.getPrimalAspects().indexOf(aspect);
+				generateVisEffect(world.provider.dimensionId, x, y, z, node.xCoord, node.yCoord, node.zCoord, color);				
+			}
+			if (amount <= 0) {
+				break;
+			}
+		}
+		
+		return drainedAmount;
+	}
+	
+	public static void generateVisEffect(int dim, int x, int y, int z, int x2, int y2, int z2, int color) {
+		ThaumcraftApi.internalMethods.generateVisEffect(dim, x, y, z, x2, y2, z2, color);
+	}
+
+	public static HashMap<Integer, HashMap<WorldCoordinates, WeakReference<TileVisNode>>> sources = new HashMap<Integer, HashMap<WorldCoordinates, WeakReference<TileVisNode>>>();
+
+	public static void addSource(World world, TileVisNode vs) {
+		HashMap<WorldCoordinates, WeakReference<TileVisNode>> sourcelist = sources
+				.get(world.provider.dimensionId);
+		if (sourcelist == null) {
+			sourcelist = new HashMap<WorldCoordinates, WeakReference<TileVisNode>>();
+		}
+		sourcelist.put(vs.getLocation(), new WeakReference(vs));
+		sources.put(world.provider.dimensionId, sourcelist);
+		nearbyNodes.clear();
+	}
+
+	public static boolean isNodeValid(WeakReference<TileVisNode> node) {
+		if (node == null || node.get() == null || node.get().isInvalid())
+			return false;
+		return true;
+	}
+
+	public static WeakReference<TileVisNode> addNode(World world, TileVisNode vn) {
+		WeakReference ref = new WeakReference(vn);
+
+		HashMap<WorldCoordinates, WeakReference<TileVisNode>> sourcelist = sources
+				.get(world.provider.dimensionId);
+		if (sourcelist == null) {
+			sourcelist = new HashMap<WorldCoordinates, WeakReference<TileVisNode>>();
+			return null;
+		}
+
+		ArrayList<Object[]> nearby = new ArrayList<Object[]>();
+
+		for (WeakReference<TileVisNode> root : sourcelist.values()) {
+			if (!isNodeValid(root))
+				continue;
+
+			TileVisNode source = root.get();
+
+			float r = inRange(world, vn.getLocation(), source.getLocation(),
+					vn.getRange());
+			if (r > 0) {
+				nearby.add(new Object[] { source, r - vn.getRange() * 2 });
+			}
+			
+			nearby = findClosestNodes(vn, source, nearby);
+			cache.clear();
+		}
+
+		float dist = Float.MAX_VALUE;
+		TileVisNode closest = null;
+		if (nearby.size() > 0) {
+			for (Object[] o : nearby) {
+				if ((Float) o[1] < dist &&
+					(vn.getAttunement() == -1 || ((TileVisNode) o[0]).getAttunement() == -1 || 
+						vn.getAttunement() == ((TileVisNode) o[0]).getAttunement())//) {
+					 && canNodeBeSeen(vn,(TileVisNode)o[0])) {
+					dist = (Float) o[1];
+					closest = (TileVisNode) o[0];					
+				}
+			}
+		}
+		if (closest != null) {
+			closest.getChildren().add(ref);
+			nearbyNodes.clear();
+			return new WeakReference(closest);
+		}
+
+		return null;
+	}
+
+	static ArrayList<WorldCoordinates> cache = new ArrayList<WorldCoordinates>();
+	public static ArrayList<Object[]> findClosestNodes(TileVisNode target,
+			TileVisNode parent, ArrayList<Object[]> in) {
+		
+		if (cache.size() > 512 || cache.contains(new WorldCoordinates(parent))) return in;
+		cache.add(new WorldCoordinates(parent));
+		
+		for (WeakReference<TileVisNode> childWR : parent.getChildren()) {
+			TileVisNode child = childWR.get();
+
+			if (child != null && !child.equals(target) && !child.equals(parent)) {
+				float r2 = inRange(child.getWorldObj(), child.getLocation(),
+						target.getLocation(), target.getRange());
+				if (r2 > 0) {
+					in.add(new Object[] { child, r2 });
+				}
+				
+				in = findClosestNodes(target, child, in);
+			}
+		}
+		return in;
+	}
+
+	private static float inRange(World world, WorldCoordinates cc1,
+			WorldCoordinates cc2, int range) {
+		float distance = cc1.getDistanceSquaredToWorldCoordinates(cc2);
+		return distance > range * range ? -1 : distance;
+	}
+
+	private static HashMap<WorldCoordinates, ArrayList<WeakReference<TileVisNode>>> nearbyNodes = new HashMap<WorldCoordinates, ArrayList<WeakReference<TileVisNode>>>();
+
+	private static void calculateNearbyNodes(World world, int x, int y, int z) {
+
+		HashMap<WorldCoordinates, WeakReference<TileVisNode>> sourcelist = sources
+				.get(world.provider.dimensionId);
+		if (sourcelist == null) {
+			sourcelist = new HashMap<WorldCoordinates, WeakReference<TileVisNode>>();
+			return;
+		}
+
+		ArrayList<WeakReference<TileVisNode>> cn = new ArrayList<WeakReference<TileVisNode>>();
+		WorldCoordinates drainer = new WorldCoordinates(x, y, z,
+				world.provider.dimensionId);
+
+		ArrayList<Object[]> nearby = new ArrayList<Object[]>();
+
+		for (WeakReference<TileVisNode> root : sourcelist.values()) {
+			
+			if (!isNodeValid(root))
+				continue;
+
+			TileVisNode source = root.get();
+			
+			TileVisNode closest = null;
+			float range = Float.MAX_VALUE;
+
+			float r = inRange(world, drainer, source.getLocation(),
+					source.getRange());
+			if (r > 0) {
+				range = r;
+				closest = source;
+			}
+			
+			ArrayList<WeakReference<TileVisNode>> children = new ArrayList<WeakReference<TileVisNode>>();
+			children = getAllChildren(source,children);
+			
+			for (WeakReference<TileVisNode> child : children) {
+				TileVisNode n = child.get();
+				if (n != null && !n.equals(root)) {
+					
+					float r2 = inRange(n.getWorldObj(), n.getLocation(),
+							drainer, n.getRange());
+					if (r2 > 0 && r2 < range) {
+						range = r2;
+						closest = n;
+					}
+				}
+			}
+
+			if (closest != null) {
+				
+				cn.add(new WeakReference(closest));
+			}
+		}
+
+		nearbyNodes.put(drainer, cn);
+	}
+	
+	private static ArrayList<WeakReference<TileVisNode>> getAllChildren(TileVisNode source, ArrayList<WeakReference<TileVisNode>> list) {
+		for (WeakReference<TileVisNode> child : source.getChildren()) {
+			TileVisNode n = child.get();
+			
+			if (n != null && n.getWorldObj()!=null && isChunkLoaded(n.getWorldObj(), n.xCoord, n.zCoord)) {
+				list.add(child);
+				list = getAllChildren(n,list);
+			}
+		}
+		return list;
+	}
+	
+	public static boolean isChunkLoaded(World world, int x, int z) {
+		int xx = x >> 4;
+		int zz = z >> 4;
+		return world.getChunkProvider().chunkExists(xx, zz);
+	}
+
+	 public static boolean canNodeBeSeen(TileVisNode source,TileVisNode target)
+	 {		 
+		 MovingObjectPosition mop = ThaumcraftApiHelper.rayTraceIgnoringSource(source.getWorldObj(), 
+				 Vec3.createVectorHelper(source.xCoord+.5, source.yCoord+.5,source.zCoord+.5),
+				 Vec3.createVectorHelper(target.xCoord+.5, target.yCoord+.5,target.zCoord+.5),
+				 false, true, false);
+		 return  mop == null || (mop.typeOfHit==MovingObjectType.BLOCK &&
+				 mop.blockX==target.xCoord && mop.blockY==target.yCoord && mop.blockZ==target.zCoord);
+	 }
+
+	// public static HashMap<WorldCoordinates,WeakReference<TileVisNode>>
+	// noderef = new HashMap<WorldCoordinates,WeakReference<TileVisNode>>();
+	//
+	// public static TileVisNode getClosestNodeWithinRadius(World world, int x,
+	// int y, int z, int radius) {
+	// TileVisNode out = null;
+	// WorldCoordinates wc = null;
+	// float cd = Float.MAX_VALUE;
+	// for (int sx = x - radius; sx <= x + radius; sx++) {
+	// for (int sy = y - radius; sy <= y + radius; sy++) {
+	// for (int sz = z - radius; sz <= z + radius; sz++) {
+	// wc = new WorldCoordinates(sx,sy,sz,world.provider.dimensionId);
+	// if (noderef.containsKey(wc)) {
+	// float d = wc.getDistanceSquared(x, y, z);
+	// if (d<radius*radius && noderef.get(wc).get()!=null &&
+	// !noderef.get(wc).get().isReceiver() &&
+	// isNodeValid(noderef.get(wc).get().getParent())
+	// ) {
+	// out = noderef.get(wc).get();
+	// cd = d;
+	// }
+	// }
+	// }
+	// }
+	// }
+	// return out;
+	// }
+
+}

--- a/src/api/java/thaumcraft/api/wands/FocusUpgradeType.java
+++ b/src/api/java/thaumcraft/api/wands/FocusUpgradeType.java
@@ -1,0 +1,114 @@
+package thaumcraft.api.wands;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+
+import org.apache.logging.log4j.LogManager;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public class FocusUpgradeType {
+
+	public static FocusUpgradeType[] types = new FocusUpgradeType[20];
+	
+	public short id;
+	
+	public ResourceLocation icon;
+	
+	public String name;
+	
+	public String text;
+	
+	/**
+	 * What aspects are used to calculate the cost of this upgrade. The amounts given is ignored, just the type is used for the calculation.
+	 */
+	public AspectList aspects;
+
+	
+
+	public FocusUpgradeType(int id, ResourceLocation icon, String name, String text, AspectList aspects) {
+		this.id = (short) id;	
+		this.icon = icon;
+		this.name = name;
+		this.text = text;
+		this.aspects = aspects;
+		
+		if (id<types.length && types[id]!=null) {
+			LogManager.getLogger("THAUMCRAFT").fatal("Focus Upgrade id "+id+" already occupied. Ignoring.");
+			return;
+		}
+		
+		// allocate space
+		if (id>=types.length) {
+			FocusUpgradeType[] temp = new FocusUpgradeType[id+1];
+			System.arraycopy(types, 0, temp, 0, id);
+			types = temp;
+		}
+		
+		types[id] = this;
+	}	
+	
+	public String getLocalizedName() {
+		return StatCollector.translateToLocal(name);
+	}
+	
+	public String getLocalizedText() {
+		return StatCollector.translateToLocal(text);
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof FocusUpgradeType) {
+			return this.id == ((FocusUpgradeType)obj).id;
+		} else return false;
+	}
+
+	// basic upgrade types
+	public static FocusUpgradeType potency = new FocusUpgradeType( 0,
+			new ResourceLocation("thaumcraft", "textures/foci/potency.png"),
+			"focus.upgrade.potency.name","focus.upgrade.potency.text",
+			new AspectList().add(Aspect.WEAPON,1));
+	
+	public static FocusUpgradeType frugal = new FocusUpgradeType( 1,
+			new ResourceLocation("thaumcraft", "textures/foci/frugal.png"),
+			"focus.upgrade.frugal.name","focus.upgrade.frugal.text",
+			new AspectList().add(Aspect.HUNGER,1));
+	
+	public static FocusUpgradeType treasure = new FocusUpgradeType( 2,
+			new ResourceLocation("thaumcraft", "textures/foci/treasure.png"),
+			"focus.upgrade.treasure.name","focus.upgrade.treasure.text",
+			new AspectList().add(Aspect.GREED,1));
+	
+	public static FocusUpgradeType enlarge = new FocusUpgradeType( 3,
+			new ResourceLocation("thaumcraft", "textures/foci/enlarge.png"),
+			"focus.upgrade.enlarge.name","focus.upgrade.enlarge.text",
+			new AspectList().add(Aspect.TRAVEL,1));
+
+	public static FocusUpgradeType alchemistsfire = new FocusUpgradeType( 4,
+			new ResourceLocation("thaumcraft", "textures/foci/alchemistsfire.png"),
+			"focus.upgrade.alchemistsfire.name","focus.upgrade.alchemistsfire.text",
+			new AspectList().add(Aspect.ENERGY,1).add(Aspect.SLIME,1));
+	
+	public static FocusUpgradeType alchemistsfrost = new FocusUpgradeType( 5,
+			new ResourceLocation("thaumcraft", "textures/foci/alchemistsfrost.png"),
+			"focus.upgrade.alchemistsfrost.name","focus.upgrade.alchemistsfrost.text",
+			new AspectList().add(Aspect.COLD,1).add(Aspect.TRAP,1));
+	
+	public static FocusUpgradeType architect = new FocusUpgradeType( 6,
+			new ResourceLocation("thaumcraft", "textures/foci/architect.png"),
+			"focus.upgrade.architect.name","focus.upgrade.architect.text",
+			new AspectList().add(Aspect.CRAFT,1));
+	
+	public static FocusUpgradeType extend = new FocusUpgradeType( 7,
+			new ResourceLocation("thaumcraft", "textures/foci/extend.png"),
+			"focus.upgrade.extend.name","focus.upgrade.extend.text",
+			new AspectList().add(Aspect.EXCHANGE,1));
+	
+	public static FocusUpgradeType silktouch = new FocusUpgradeType( 8,
+			new ResourceLocation("thaumcraft", "textures/foci/silktouch.png"),
+			"focus.upgrade.silktouch.name","focus.upgrade.silktouch.text",
+			new AspectList().add(Aspect.GREED,1));
+	
+	
+}

--- a/src/api/java/thaumcraft/api/wands/IWandRodOnUpdate.java
+++ b/src/api/java/thaumcraft/api/wands/IWandRodOnUpdate.java
@@ -1,0 +1,16 @@
+package thaumcraft.api.wands;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * 
+ * @author azanor
+ * 
+ * Implemented by a class that you wish to be called whenever a wand with this rod performs its
+ * update tick. 
+ *
+ */
+public interface IWandRodOnUpdate {
+	void onUpdate(ItemStack itemstack, EntityPlayer player);
+}

--- a/src/api/java/thaumcraft/api/wands/IWandTriggerManager.java
+++ b/src/api/java/thaumcraft/api/wands/IWandTriggerManager.java
@@ -1,0 +1,15 @@
+package thaumcraft.api.wands;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IWandTriggerManager {
+
+	/**
+	 * This class will be called by wands with the proper parameters. It is up to you to decide what to do with them.
+	 */
+	public boolean performTrigger(World world, ItemStack wand, EntityPlayer player, 
+			int x, int y, int z, int side, int event);
+	
+}

--- a/src/api/java/thaumcraft/api/wands/IWandable.java
+++ b/src/api/java/thaumcraft/api/wands/IWandable.java
@@ -1,0 +1,25 @@
+package thaumcraft.api.wands;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+/**
+ *  
+ * @author azanor
+ * 
+ * Add this to a tile entity that you wish wands to interact with in some way. 
+ *
+ */
+
+public interface IWandable {
+
+	public int onWandRightClick(World world, ItemStack wandstack, EntityPlayer player, int x, int y, int z, int side, int md);
+	
+	public ItemStack onWandRightClick(World world, ItemStack wandstack, EntityPlayer player);
+	
+	public void onUsingWandTick(ItemStack wandstack, EntityPlayer player, int count);
+	
+	public void onWandStoppedUsing(ItemStack wandstack, World world, EntityPlayer player, int count);
+	
+}

--- a/src/api/java/thaumcraft/api/wands/ItemFocusBasic.java
+++ b/src/api/java/thaumcraft/api/wands/ItemFocusBasic.java
@@ -1,0 +1,276 @@
+package thaumcraft.api.wands;
+
+import java.text.DecimalFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.EnumRarity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class ItemFocusBasic extends Item {
+	
+	public ItemFocusBasic ()
+    {
+        super();
+        maxStackSize = 1;
+        canRepair=false;
+        this.setMaxDamage(0);
+    }
+	
+	public IIcon icon;
+	
+	@SideOnly(Side.CLIENT)
+	@Override
+	public IIcon getIconFromDamage(int par1) {
+		return icon;
+	}
+	
+	@Override
+	public boolean isDamageable() {
+		return false;
+	}
+
+	@Override
+	public void addInformation(ItemStack stack,EntityPlayer player, List list, boolean par4) {
+		AspectList al = this.getVisCost(stack);
+		if (al!=null && al.size()>0) {
+			list.add(StatCollector.translateToLocal(isVisCostPerTick(stack)?"item.Focus.cost2":"item.Focus.cost1"));
+			for (Aspect aspect:al.getAspectsSorted()) {
+				DecimalFormat myFormatter = new DecimalFormat("#####.##");
+				String amount = myFormatter.format(al.getAmount(aspect)/100f);
+				list.add(" \u00A7"+aspect.getChatcolor()+aspect.getName()+"\u00A7r x "+ amount);				
+			}
+		}
+		addFocusInformation(stack,player,list,par4);
+	}
+	
+	public void addFocusInformation(ItemStack focusstack,EntityPlayer player, List list, boolean par4) {
+		LinkedHashMap<Short, Integer> map = new LinkedHashMap<Short, Integer>();
+		for (short id:this.getAppliedUpgrades(focusstack)) {
+			if (id>=0) {
+				int amt = 1;
+				if (map.containsKey(id)) {
+					amt = map.get(id) + 1;				
+				}
+				map.put(id, amt);
+			}
+		}
+		for (Short id:map.keySet()) {	
+			list.add(EnumChatFormatting.DARK_PURPLE +FocusUpgradeType.types[id].getLocalizedName()+
+					(map.get(id)>1?" "+StatCollector.translateToLocal("enchantment.level." + map.get(id)):""));
+		}
+	}
+	
+	/**
+	 * Purely for display on the focus tooltip (see addInformation method above)
+	 */
+	public boolean isVisCostPerTick(ItemStack focusstack) {
+		return false;
+	}
+	
+	@Override
+	public EnumRarity getRarity(ItemStack focusstack)
+    {
+        return EnumRarity.rare;
+    }	
+	
+	/**
+	 * What color will the focus orb be rendered on the held wand
+	 */
+	public int getFocusColor(ItemStack focusstack) {
+		return 0;
+	}
+
+	
+	/**
+	 * Does the focus have ornamentation like the focus of the nine hells. Ornamentation is a standard icon rendered in a cross around the focus
+	 */	
+	public IIcon getOrnament(ItemStack focusstack) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	/**
+	 * An icon to be rendered inside the focus itself
+	 */
+	public IIcon getFocusDepthLayerIcon(ItemStack focusstack) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	public enum WandFocusAnimation {
+		WAVE, CHARGE;
+	}
+
+	public WandFocusAnimation getAnimation(ItemStack focusstack) {
+		return WandFocusAnimation.WAVE;
+	}
+	
+	/**
+	 * Just insert two alphanumeric characters before this string in your focus item class
+	 */
+	public String getSortingHelper(ItemStack focusstack) {		
+		String out="";
+		for (short id:this.getAppliedUpgrades(focusstack)) {
+			out = out + id;
+		}
+		return out;
+	}
+	
+	
+	/**
+	 * How much vis does this focus consume per activation. 
+	 */
+	public AspectList getVisCost(ItemStack focusstack) {
+		return null;
+	}
+	
+	/**
+	 * This returns how many milliseconds must pass before the focus can be activated again.
+	 */	
+	public int getActivationCooldown(ItemStack focusstack) {
+		return 0;
+	}	
+	
+	/**
+	 * Used by foci like equal trade to determine their area in artchitect mode 
+	 */
+	public int getMaxAreaSize(ItemStack focusstack) {
+		return 1;
+	}
+	
+	/**
+	 * What upgrades can be applied to this focus for ranks 1 to 5
+	 */
+	public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {
+		return null;
+	}
+	
+	/**
+	 * What upgrades does the focus currently have
+	 */
+	public short[] getAppliedUpgrades(ItemStack focusstack) {
+		short[] l = new short[] {-1,-1,-1,-1,-1};
+		NBTTagList nbttaglist = getFocusUpgradeTagList(focusstack);
+        if (nbttaglist == null)
+        {
+            return l;
+        }
+        else
+        {        	
+            for (int j = 0; j < nbttaglist.tagCount(); ++j)
+            {
+            	if (j>=5) break;
+            	l[j] = nbttaglist.getCompoundTagAt(j).getShort("id");
+            }
+
+            return l;
+        }
+	}
+	
+	public boolean applyUpgrade(ItemStack focusstack, FocusUpgradeType type, int rank) {
+		short[] upgrades = getAppliedUpgrades(focusstack);
+		if (upgrades[rank-1]!=-1 || rank<1 || rank>5) {
+			return false;
+		}
+		upgrades[rank-1] = type.id;
+		setFocusUpgradeTagList(focusstack, upgrades);
+		return true;
+	}
+	
+	/**
+	 * Use this method to define custom logic about which upgrades can be applied. This can be used to set up upgrade "trees" 
+	 * that make certain upgrades available only when others are unlocked first, when certain research is completed, or similar logic.
+	 * 
+	 */
+	public boolean canApplyUpgrade(ItemStack focusstack, EntityPlayer player, FocusUpgradeType type, int rank) {
+		return true;
+	}
+
+	/**
+	 * Does this focus have the passed upgrade type
+	 */
+	public boolean isUpgradedWith(ItemStack focusstack, FocusUpgradeType focusUpgradetype) {
+		return getUpgradeLevel(focusstack,focusUpgradetype)>0;
+	}
+
+	/**
+	 * What level is the passed upgrade type on the focus. If it is not present it returns 0
+	 */
+	public int getUpgradeLevel(ItemStack focusstack, FocusUpgradeType focusUpgradetype) {
+		short[] list = getAppliedUpgrades(focusstack);
+		int level=0;
+		for (short id:list) {
+			if (id == focusUpgradetype.id)
+            {
+                level++;
+            }
+		}
+        return level;
+	}	
+	
+	public ItemStack onFocusRightClick(ItemStack wandstack, World world,EntityPlayer player, MovingObjectPosition movingobjectposition) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	public void onUsingFocusTick(ItemStack wandstack, EntityPlayer player,int count) {
+		// TODO Auto-generated method stub		
+	}
+	
+	public void onPlayerStoppedUsingFocus(ItemStack wandstack, World world,	EntityPlayer player, int count) {
+		// TODO Auto-generated method stub
+		
+	}
+	
+	public boolean onFocusBlockStartBreak(ItemStack wandstack, int x, int y,int z, EntityPlayer player) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+	
+	/**
+	 * Internal helper methods
+	 */
+	private NBTTagList getFocusUpgradeTagList(ItemStack focusstack)
+    {
+        return focusstack.stackTagCompound == null ? null : focusstack.stackTagCompound.getTagList("upgrade", 10);
+    }
+	
+	private void setFocusUpgradeTagList(ItemStack focusstack, short[] upgrades) {
+		if (!focusstack.hasTagCompound()) 
+			focusstack.setTagCompound(new NBTTagCompound());
+		NBTTagCompound nbttagcompound = focusstack.getTagCompound();
+		NBTTagList tlist = new NBTTagList();
+		nbttagcompound.setTag("upgrade", tlist);
+		for (short id : upgrades) {		
+			NBTTagCompound f = new NBTTagCompound();
+			f.setShort("id", id);
+			tlist.appendTag(f);
+		}
+	}
+
+	@Override
+	public void onUpdate(ItemStack stack, World world, Entity entity, int p_77663_4_, boolean p_77663_5_) {
+		if (stack.stackTagCompound !=null && stack.stackTagCompound.hasKey("ench")) {
+			stack.stackTagCompound.removeTag("ench");
+		}
+		super.onUpdate(stack, world, entity, p_77663_4_, p_77663_5_);
+	}
+
+	
+	
+}

--- a/src/api/java/thaumcraft/api/wands/StaffRod.java
+++ b/src/api/java/thaumcraft/api/wands/StaffRod.java
@@ -1,0 +1,48 @@
+package thaumcraft.api.wands;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * This class is used to keep the material information for the various rods. 
+ * It is also used to generate the wand recipes ingame.
+ *
+ */
+public class StaffRod extends WandRod {
+	
+	boolean runes=false;
+
+	public StaffRod(String tag, int capacity, ItemStack item, int craftCost) {
+		super(tag+"_staff", capacity, item, craftCost);
+		this.texture = new ResourceLocation("thaumcraft","textures/models/wand_rod_"+tag+".png");
+	}
+
+	public StaffRod(String tag, int capacity, ItemStack item, int craftCost,
+			IWandRodOnUpdate onUpdate, ResourceLocation texture) {
+		super(tag+"_staff", capacity, item, craftCost, onUpdate, texture);
+	}
+
+	public StaffRod(String tag, int capacity, ItemStack item, int craftCost,
+			IWandRodOnUpdate onUpdate) {
+		super(tag+"_staff", capacity, item, craftCost, onUpdate);
+		this.texture = new ResourceLocation("thaumcraft","textures/models/wand_rod_"+tag+".png");
+	}
+
+	public StaffRod(String tag, int capacity, ItemStack item, int craftCost,
+			ResourceLocation texture) {
+		super(tag+"_staff", capacity, item, craftCost, texture);
+	}
+
+	public boolean hasRunes() {
+		return runes;
+	}
+
+	public void setRunes(boolean hasRunes) {
+		this.runes = hasRunes;
+	}
+
+	
+}

--- a/src/api/java/thaumcraft/api/wands/WandCap.java
+++ b/src/api/java/thaumcraft/api/wands/WandCap.java
@@ -1,0 +1,129 @@
+package thaumcraft.api.wands;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import thaumcraft.api.aspects.Aspect;
+
+/**
+ * This class is used to keep the material information for the various caps. 
+ * It is also used to generate the wand recipes ingame.
+ * @author Azanor
+ *
+ */
+public class WandCap {
+
+	private String tag;
+	
+	/**
+	 * Cost to craft this wand. Combined with the rod cost.
+	 */
+	private int craftCost;
+	
+	/**
+	 * the amount by which all aspect costs are multiplied
+	 */
+	float baseCostModifier; 
+	
+	/**
+	 * specifies a list of primal aspects that use the special discount figure instead of the normal discount.
+	 */
+	List<Aspect> specialCostModifierAspects;
+	
+	/**
+	 * the amount by which the specified aspect costs are multiplied
+	 */
+	float specialCostModifier;
+	
+	/**
+	 * The texture that will be used for the ingame wand cap
+	 */
+	ResourceLocation texture;
+	
+	/**
+	 * the actual item that makes up this cap and will be used to generate the wand recipes
+	 */
+	ItemStack item;
+	
+	public static LinkedHashMap<String,WandCap> caps = new LinkedHashMap<String,WandCap>();
+
+	public WandCap (String tag, float discount, ItemStack item, int craftCost) {
+		this.setTag(tag);
+		this.baseCostModifier = discount;
+		this.specialCostModifierAspects = null;
+		texture = new ResourceLocation("thaumcraft","textures/models/wand_cap_"+getTag()+".png");
+		this.item=item;
+		this.setCraftCost(craftCost);
+		caps.put(tag, this);
+	}
+	
+	public WandCap (String tag, float discount, List<Aspect> specialAspects, float discountSpecial, ItemStack item, int craftCost) {
+		this.setTag(tag);
+		this.baseCostModifier = discount;
+		this.specialCostModifierAspects = specialAspects;
+		this.specialCostModifier = discountSpecial;
+		texture = new ResourceLocation("thaumcraft","textures/models/wand_cap_"+getTag()+".png");
+		this.item=item;
+		this.setCraftCost(craftCost);
+		caps.put(tag, this);
+	}
+	
+	public float getBaseCostModifier() {
+		return baseCostModifier;
+	}
+
+	public List<Aspect> getSpecialCostModifierAspects() {
+		return specialCostModifierAspects;
+	}
+
+	public float getSpecialCostModifier() {
+		return specialCostModifier;
+	}
+
+	public ResourceLocation getTexture() {
+		return texture;
+	}
+
+	public void setTexture(ResourceLocation texture) {
+		this.texture = texture;
+	}
+
+	public String getTag() {
+		return tag;
+	}
+
+	public void setTag(String tag) {
+		this.tag = tag;
+	}
+	
+
+	public ItemStack getItem() {
+		return item;
+	}
+
+	public void setItem(ItemStack item) {
+		this.item = item;
+	}
+
+	public int getCraftCost() {
+		return craftCost;
+	}
+
+	public void setCraftCost(int craftCost) {
+		this.craftCost = craftCost;
+	}
+	
+	/**
+	 * The research a player needs to have finished to be able to craft a wand with this cap. 
+	 */
+	public String getResearch() {
+		return "CAP_"+getTag();
+	}
+	
+	//  Some examples:
+	//  WandCap WAND_CAP_IRON = new WandCap("iron", 1.1f, Arrays.asList(Aspect.ORDER),1, new ItemStack(ConfigItems.itemWandCap,1,0),1);
+	//  WandCap WAND_CAP_GOLD = new WandCap("gold", 1f, new ItemStack(ConfigItems.itemWandCap,1,1),3);
+	
+}

--- a/src/api/java/thaumcraft/api/wands/WandRod.java
+++ b/src/api/java/thaumcraft/api/wands/WandRod.java
@@ -1,0 +1,158 @@
+package thaumcraft.api.wands;
+
+import java.util.LinkedHashMap;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * 
+ * @author Azanor
+ * 
+ * This class is used to keep the material information for the various rods. 
+ * It is also used to generate the wand recipes ingame.
+ *
+ */
+public class WandRod {
+
+	
+	private String tag;
+	
+	/**
+	 * Cost to craft this wand. Combined with the rod cost.
+	 */
+	private int craftCost;
+	
+	/** 
+	 * The amount of vis that can be stored - this number is actually multiplied 
+	 * by 100 for use by the wands internals
+	 */
+	int capacity;   
+
+	/**
+	 * The texture that will be used for the ingame wand rod
+	 */
+	protected ResourceLocation texture;
+	
+	/**
+	 * the actual item that makes up this rod and will be used to generate the wand recipes
+	 */
+	ItemStack item;
+	
+	/**
+	 * A class that will be called whenever the wand onUpdate tick is run
+	 */
+	IWandRodOnUpdate onUpdate;
+	
+	/**
+	 * Does the rod glow in the dark?
+	 */
+	boolean glow;
+
+	public static LinkedHashMap<String,WandRod> rods = new LinkedHashMap<String,WandRod>();
+	
+	public WandRod (String tag, int capacity, ItemStack item, int craftCost, ResourceLocation texture) {
+		this.setTag(tag);
+		this.capacity = capacity;
+		this.texture = texture;
+		this.item=item;
+		this.setCraftCost(craftCost);
+		rods.put(tag, this);
+	}
+	
+	public WandRod (String tag, int capacity, ItemStack item, int craftCost, IWandRodOnUpdate onUpdate, ResourceLocation texture) {
+		this.setTag(tag);
+		this.capacity = capacity;
+		this.texture = texture;
+		this.item=item;
+		this.setCraftCost(craftCost);
+		rods.put(tag, this);
+		this.onUpdate = onUpdate;
+	}
+
+	public WandRod (String tag, int capacity, ItemStack item, int craftCost) {
+		this.setTag(tag);
+		this.capacity = capacity;
+		this.texture = new ResourceLocation("thaumcraft","textures/models/wand_rod_"+getTag()+".png");
+		this.item=item;
+		this.setCraftCost(craftCost);
+		rods.put(tag, this);
+	}
+	
+	public WandRod (String tag, int capacity, ItemStack item, int craftCost, IWandRodOnUpdate onUpdate) {
+		this.setTag(tag);
+		this.capacity = capacity;
+		this.texture = new ResourceLocation("thaumcraft","textures/models/wand_rod_"+getTag()+".png");
+		this.item=item;
+		this.setCraftCost(craftCost);
+		rods.put(tag, this);
+		this.onUpdate = onUpdate;
+	}
+	
+	public String getTag() {
+		return tag;
+	}
+	
+	public void setTag(String tag) {
+		this.tag = tag;
+	}
+
+	public int getCapacity() {
+		return capacity;
+	}
+
+	public void setCapacity(int capacity) {
+		this.capacity = capacity;
+	}
+
+	public ResourceLocation getTexture() {
+		return texture;
+	}
+
+	public void setTexture(ResourceLocation texture) {
+		this.texture = texture;
+	}
+
+	public ItemStack getItem() {
+		return item;
+	}
+
+	public void setItem(ItemStack item) {
+		this.item = item;
+	}
+	
+	public int getCraftCost() {
+		return craftCost;
+	}
+
+	public void setCraftCost(int craftCost) {
+		this.craftCost = craftCost;
+	}
+
+	public IWandRodOnUpdate getOnUpdate() {
+		return onUpdate;
+	}
+
+	public void setOnUpdate(IWandRodOnUpdate onUpdate) {
+		this.onUpdate = onUpdate;
+	}
+
+	public boolean isGlowing() {
+		return glow;
+	}
+
+	public void setGlowing(boolean hasGlow) {
+		this.glow = hasGlow;
+	}
+	
+	/**
+	 * The research a player needs to have finished to be able to craft a wand with this rod. 
+	 */
+	public String getResearch() {
+		return "ROD_"+getTag();
+	}
+
+	//  Some examples:
+	//	WandRod WAND_ROD_WOOD = new WandRod("wood",25,new ItemStack(Item.stick),1);
+	//	WandRod WAND_ROD_BLAZE = new WandRod("blaze",100,new ItemStack(Item.blazeRod),7,new WandRodBlazeOnUpdate());
+}

--- a/src/api/java/thaumcraft/api/wands/WandTriggerRegistry.java
+++ b/src/api/java/thaumcraft/api/wands/WandTriggerRegistry.java
@@ -1,0 +1,126 @@
+package thaumcraft.api.wands;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+/**
+ * This class serves a similar function to IWandable in that it allows wands to interact
+ * with object in the world. In this case it is most useful for adding interaction with non-mod
+ * blocks where you can't control what happens in their code.
+ * Example where it is used is in crafting the thaumonomicon from a bookshelf and the
+ * crucible from a cauldron
+ * 
+ * @author azanor
+ *
+ */
+public class WandTriggerRegistry {
+	
+	private static HashMap<String,HashMap<List,List>> triggers = new HashMap<String,HashMap<List,List>>();
+	private static final String DEFAULT = "default";
+
+	/**
+	 * Registers an action to perform when a casting wand right clicks on a specific block. 
+	 * A manager class needs to be created that implements IWandTriggerManager.
+	 * @param manager
+	 * @param event a logical number that you can use to differentiate different events or actions
+	 * @param block
+	 * @param meta send -1 as a wildcard value for all possible meta values
+	 * @param modid a unique identifier. It is best to register your own triggers using your mod id to avoid conflicts with mods that register triggers for the same block
+	 */
+	public static void registerWandBlockTrigger(IWandTriggerManager manager, int event, Block block, int meta, String modid) {
+		if (!triggers.containsKey(modid)) {
+			triggers.put(modid, new HashMap<List,List>());
+		}
+		HashMap<List,List> temp = triggers.get(modid);
+		temp.put(Arrays.asList(block,meta),Arrays.asList(manager,event));
+		triggers.put(modid, temp);
+	}
+	
+	/**
+	 * for legacy support
+	 */
+	public static void registerWandBlockTrigger(IWandTriggerManager manager, int event, Block block, int meta) {
+		registerWandBlockTrigger(manager, event, block, meta, DEFAULT);
+	}
+	
+	/**
+	 * Checks all trigger registries if one exists for the given block and meta
+	 * @param block
+	 * @param meta
+	 * @return
+	 */
+	public static boolean hasTrigger(Block block, int meta) {
+		for (String modid:triggers.keySet()) {
+			HashMap<List,List> temp = triggers.get(modid);
+			if (temp.containsKey(Arrays.asList(block,meta)) ||
+					temp.containsKey(Arrays.asList(block,-1))) return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * modid sensitive version
+	 */
+	public static boolean hasTrigger(Block block, int meta, String modid) {
+		if (!triggers.containsKey(modid)) return false;
+		HashMap<List,List> temp = triggers.get(modid);
+		if (temp.containsKey(Arrays.asList(block,meta)) ||
+				temp.containsKey(Arrays.asList(block,-1))) return true;
+		return false;
+	}
+	
+	
+	/**
+	 * This is called by the onItemUseFirst function in wands. 
+	 * Parameters and return value functions like you would expect for that function.
+	 * @param world
+	 * @param wand
+	 * @param player
+	 * @param x
+	 * @param y
+	 * @param z
+	 * @param side
+	 * @param block
+	 * @param meta
+	 * @return
+	 */
+	public static boolean performTrigger(World world, ItemStack wand, EntityPlayer player, 
+			int x, int y, int z, int side, Block block, int meta) {
+		
+		for (String modid:triggers.keySet()) {
+			HashMap<List,List> temp = triggers.get(modid);
+			List l = temp.get(Arrays.asList(block,meta));
+			if (l==null) l = temp.get(Arrays.asList(block,-1));
+			if (l==null) continue;
+			
+			IWandTriggerManager manager = (IWandTriggerManager) l.get(0);
+			int event = (Integer) l.get(1);
+			boolean result = manager.performTrigger(world, wand, player, x, y, z, side, event);
+			if (result) return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * modid sensitive version
+	 */
+	public static boolean performTrigger(World world, ItemStack wand, EntityPlayer player, 
+			int x, int y, int z, int side, Block block, int meta, String modid) {
+		if (!triggers.containsKey(modid)) return false;
+		HashMap<List,List> temp = triggers.get(modid);
+		List l = temp.get(Arrays.asList(block,meta));
+		if (l==null) l = temp.get(Arrays.asList(block,-1));
+		if (l==null) return false;
+		
+		IWandTriggerManager manager = (IWandTriggerManager) l.get(0);
+		int event = (Integer) l.get(1);
+		return manager.performTrigger(world, wand, player, x, y, z, side, event);
+	}
+		
+}

--- a/src/main/java/org/dave/CompactMachines/CompactMachines.java
+++ b/src/main/java/org/dave/CompactMachines/CompactMachines.java
@@ -44,7 +44,7 @@ import cpw.mods.fml.relauncher.Side;
 		modid = Reference.MOD_ID,
 		name = Reference.MOD_NAME,
 		version = Reference.VERSION,
-		dependencies = "after:appliedenergistics2;after:ProjRed|Transmission;after:OpenComputers;after:Waila;after:Botania;after:LookingGlass;",
+		dependencies = "after:appliedenergistics2;after:ProjRed|Transmission;after:OpenComputers;after:Waila;after:Botania;after:LookingGlass;after:Thaumcraft;",
 		guiFactory = "org.dave.CompactMachines.client.CMGuiFactory"
 )
 public class CompactMachines {
@@ -96,6 +96,7 @@ public class CompactMachines {
 		Reference.OC_AVAILABLE = Loader.isModLoaded("OpenComputers");
 		Reference.BOTANIA_AVAILABLE = Loader.isModLoaded("Botania");
 		Reference.MEK_AVAILABLE = Loader.isModLoaded("Mekanism");
+		Reference.THAUMCRAFT_AVAILABLE = Loader.isModLoaded("Thaumcraft");
 
 		// Insist on keeping an already registered dimension by registering in pre-init.
 		if (ConfigurationHandler.dimensionId != -1) {

--- a/src/main/java/org/dave/CompactMachines/CompactMachines.java
+++ b/src/main/java/org/dave/CompactMachines/CompactMachines.java
@@ -44,7 +44,7 @@ import cpw.mods.fml.relauncher.Side;
 		modid = Reference.MOD_ID,
 		name = Reference.MOD_NAME,
 		version = Reference.VERSION,
-		dependencies = "after:appliedenergistics2;after:ProjRed|Transmission;after:OpenComputers;after:Waila;after:Botania;after:LookingGlass;after:Thaumcraft;",
+		dependencies = "after:appliedenergistics2;after:ProjRed|Transmission;after:OpenComputers;after:Waila;after:Botania;after:LookingGlass;after:Thaumcraft;after:PneumaticCraft;",
 		guiFactory = "org.dave.CompactMachines.client.CMGuiFactory"
 )
 public class CompactMachines {
@@ -97,6 +97,7 @@ public class CompactMachines {
 		Reference.BOTANIA_AVAILABLE = Loader.isModLoaded("Botania");
 		Reference.MEK_AVAILABLE = Loader.isModLoaded("Mekanism");
 		Reference.THAUMCRAFT_AVAILABLE = Loader.isModLoaded("Thaumcraft");
+		Reference.PNEUMATICCRAFT_AVAILABLE = Loader.isModLoaded("PneumaticCraft");
 
 		// Insist on keeping an already registered dimension by registering in pre-init.
 		if (ConfigurationHandler.dimensionId != -1) {

--- a/src/main/java/org/dave/CompactMachines/block/BlockInterface.java
+++ b/src/main/java/org/dave/CompactMachines/block/BlockInterface.java
@@ -45,6 +45,17 @@ public class BlockInterface extends BlockProtected implements ITileEntityProvide
 	}
 
 	@Override
+	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		super.onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
+
+		if (!(world.getTileEntity(x, y, z) instanceof TileEntityInterface)) {
+			return;
+		}
+
+		((TileEntityInterface)world.getTileEntity(x, y, z)).onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
+	}
+
+	@Override
 	public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z) {
 		return false;
 	}

--- a/src/main/java/org/dave/CompactMachines/block/BlockMachine.java
+++ b/src/main/java/org/dave/CompactMachines/block/BlockMachine.java
@@ -308,4 +308,15 @@ public class BlockMachine extends BlockCM implements ITileEntityProvider
 	public int damageDropped(int meta) {
 		return meta;
 	}
+
+	@Override
+	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		super.onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
+
+		if (!(world.getTileEntity(x, y, z) instanceof TileEntityMachine)) {
+			return;
+		}
+
+		((TileEntityMachine)world.getTileEntity(x, y, z)).onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
+	}
 }

--- a/src/main/java/org/dave/CompactMachines/handler/ConfigurationHandler.java
+++ b/src/main/java/org/dave/CompactMachines/handler/ConfigurationHandler.java
@@ -21,10 +21,12 @@ public class ConfigurationHandler {
 	public static int			capacityFluid;
 	public static int			capacityGas;
 	public static int			capacityMana;
+	public static int			capacityEssentia;
 	public static int			cooldownRF;
 	public static int			cooldownItems;
 	public static int			cooldownFluid;
 	public static int			cooldownGas;
+	public static int			cooldownEssentia;
 	public static String		upgradeItem;
 	public static boolean		allowEntanglement;
 	public static boolean		keepPlayersInsideOfRooms;
@@ -42,6 +44,7 @@ public class ConfigurationHandler {
 	public static boolean		enableIntegrationMekanism;
 	public static boolean		enableIntegrationProjectRed;
 	public static boolean		enableIntegrationOpenComputers;
+	public static boolean		enableIntegrationThaumcraft;
 
 	public static boolean		allowRespawning;
 
@@ -86,16 +89,19 @@ public class ConfigurationHandler {
 		enableIntegrationMekanism = configuration.getBoolean("Mekanism", "Integration", true, "Transfer Mekanism Gas");
 		enableIntegrationProjectRed = configuration.getBoolean("ProjectRed", "Integration", true, "Transfer bundled cable signals through Compact Machines");
 		enableIntegrationOpenComputers = configuration.getBoolean("OpenComputers", "Integration", true, "Allow OpenComputers network connections through Compact Machines");
+		enableIntegrationThaumcraft = configuration.getBoolean("Thaumcraft", "Integration", true, "Allow Thaumcraft Essentia transport through Compact Machines");
 
 		cooldownRF = configuration.getInt("cooldownRF", "CompactMachines", 0, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Redstone Flux, i.e. 20 => 10000 RF/s, 0 => 10000 RF/t");
 		cooldownItems = configuration.getInt("cooldownItems", "CompactMachines", 10, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Items, i.e. 40 => 1 Stack every two seconds");
 		cooldownFluid = configuration.getInt("cooldownFluid", "CompactMachines", 10, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Fluids, i.e. 0 => 1 Bucket per tick");
 		cooldownGas = configuration.getInt("cooldownGas", "CompactMachines", 0, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Gases, i.e. 0 => 1024 units per tick");
+		cooldownEssentia = configuration.getInt("cooldownEssentia", "CompactMachines", 0, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Essentia, i.e. 0 => 1 Essentia per tick");
 
 		capacityRF = configuration.getInt("capacityRF", "CompactMachines", 10000, 0, Integer.MAX_VALUE, "Maximum amount of RF a CM buffer can hold.");
 		capacityFluid = configuration.getInt("capacityFluid", "CompactMachines", 1000, 0, Integer.MAX_VALUE, "Maximum amount of fluid (in mB) a CM buffer can hold.");
 		capacityGas = configuration.getInt("capacityGas", "CompactMachines", 1024, 0, Integer.MAX_VALUE, "Maximum amount of gas a CM buffer can hold.");
 		capacityMana = configuration.getInt("capacityMana", "CompactMachines", 10000, 0, Integer.MAX_VALUE, "Maximum amount of Botania Mana a CM buffer can hold.");
+		capacityEssentia = configuration.getInt("capacityEssentia", "CompactMachines", 64, 0, Integer.MAX_VALUE, "Maximum amount of Thaumcraft Essentia a CM buffer can hold.");
 
 		int red = configuration.getInt("psdDisplayColor.red", "Rendering", 0x27, 0, Integer.MAX_VALUE, "Font color for the PSD");
 		int green = configuration.getInt("psdDisplayColor.green", "Rendering", 0xEB, 0, Integer.MAX_VALUE, "");

--- a/src/main/java/org/dave/CompactMachines/handler/ConfigurationHandler.java
+++ b/src/main/java/org/dave/CompactMachines/handler/ConfigurationHandler.java
@@ -45,6 +45,7 @@ public class ConfigurationHandler {
 	public static boolean		enableIntegrationProjectRed;
 	public static boolean		enableIntegrationOpenComputers;
 	public static boolean		enableIntegrationThaumcraft;
+	public static boolean		enableIntegrationPneumaticCraft;
 
 	public static boolean		allowRespawning;
 
@@ -90,6 +91,7 @@ public class ConfigurationHandler {
 		enableIntegrationProjectRed = configuration.getBoolean("ProjectRed", "Integration", true, "Transfer bundled cable signals through Compact Machines");
 		enableIntegrationOpenComputers = configuration.getBoolean("OpenComputers", "Integration", true, "Allow OpenComputers network connections through Compact Machines");
 		enableIntegrationThaumcraft = configuration.getBoolean("Thaumcraft", "Integration", true, "Allow Thaumcraft Essentia transport through Compact Machines");
+		enableIntegrationPneumaticCraft = configuration.getBoolean("PneumaticCraft", "Integration", true, "Allow PneumaticCraft Pressure transport through Compact Machines");
 
 		cooldownRF = configuration.getInt("cooldownRF", "CompactMachines", 0, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Redstone Flux, i.e. 20 => 10000 RF/s, 0 => 10000 RF/t");
 		cooldownItems = configuration.getInt("cooldownItems", "CompactMachines", 10, 0, Integer.MAX_VALUE, "Number of ticks between each import/export action for Items, i.e. 40 => 1 Stack every two seconds");

--- a/src/main/java/org/dave/CompactMachines/handler/SharedStorageHandler.java
+++ b/src/main/java/org/dave/CompactMachines/handler/SharedStorageHandler.java
@@ -29,6 +29,7 @@ import org.dave.CompactMachines.integration.fluid.FluidSharedStorage;
 import org.dave.CompactMachines.integration.gas.GasSharedStorage;
 import org.dave.CompactMachines.integration.item.ItemSharedStorage;
 import org.dave.CompactMachines.integration.opencomputers.OpenComputersSharedStorage;
+import org.dave.CompactMachines.integration.pneumaticcraft.PneumaticCraftSharedStorage;
 import org.dave.CompactMachines.integration.redstoneflux.FluxSharedStorage;
 import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.reference.Reference;
@@ -93,6 +94,10 @@ public class SharedStorageHandler {
 
 		if(Reference.THAUMCRAFT_AVAILABLE) {
 			registerModInteraction("thaumcraft", ThaumcraftSharedStorage.class);
+		}
+
+		if(Reference.PNEUMATICCRAFT_AVAILABLE) {
+			registerModInteraction("PneumaticCraft", PneumaticCraftSharedStorage.class);
 		}
 
 		if (!client) {

--- a/src/main/java/org/dave/CompactMachines/handler/SharedStorageHandler.java
+++ b/src/main/java/org/dave/CompactMachines/handler/SharedStorageHandler.java
@@ -30,6 +30,7 @@ import org.dave.CompactMachines.integration.gas.GasSharedStorage;
 import org.dave.CompactMachines.integration.item.ItemSharedStorage;
 import org.dave.CompactMachines.integration.opencomputers.OpenComputersSharedStorage;
 import org.dave.CompactMachines.integration.redstoneflux.FluxSharedStorage;
+import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.reference.Reference;
 import org.dave.CompactMachines.utility.LogHelper;
 
@@ -88,6 +89,10 @@ public class SharedStorageHandler {
 
 		if(Reference.BOTANIA_AVAILABLE) {
 			registerModInteraction("botania", BotaniaSharedStorage.class);
+		}
+
+		if(Reference.THAUMCRAFT_AVAILABLE) {
+			registerModInteraction("thaumcraft", ThaumcraftSharedStorage.class);
 		}
 
 		if (!client) {

--- a/src/main/java/org/dave/CompactMachines/integration/AbstractHoppingStorage.java
+++ b/src/main/java/org/dave/CompactMachines/integration/AbstractHoppingStorage.java
@@ -6,7 +6,7 @@ import net.minecraft.tileentity.TileEntity;
 import org.dave.CompactMachines.handler.SharedStorageHandler;
 
 public abstract class AbstractHoppingStorage extends AbstractBufferedStorage {
-	private int		hoppingMode;			// 0 - Off, 1 - To the inside, 2 - To the outside, 3 - Auto
+	private int		hoppingMode;			// 0 - Off, 1 - To the inside, 2 - To the outside, 3 - Auto, 4 - Both/Always
 	private boolean	autoHopToInside;
 
 	protected int	max_cooldown	= 20;

--- a/src/main/java/org/dave/CompactMachines/integration/pneumaticcraft/PneumaticCraftSharedStorage.java
+++ b/src/main/java/org/dave/CompactMachines/integration/pneumaticcraft/PneumaticCraftSharedStorage.java
@@ -1,0 +1,146 @@
+package org.dave.CompactMachines.integration.pneumaticcraft;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.dave.CompactMachines.handler.SharedStorageHandler;
+import org.dave.CompactMachines.integration.AbstractBufferedStorage;
+
+import pneumaticCraft.api.tileentity.AirHandlerSupplier;
+import pneumaticCraft.api.tileentity.IAirHandler;
+import pneumaticCraft.api.tileentity.IPneumaticMachine;
+import pneumaticCraft.api.tileentity.ISidedPneumaticMachine;
+
+@SuppressWarnings("deprecation")
+public class PneumaticCraftSharedStorage extends AbstractBufferedStorage {
+	public int			coord;
+	public int			side;
+	
+	private IAirHandler interfaceAirHandler;
+	private boolean 	interfaceValid = false;
+
+	private Map<Integer, IAirHandler> connectedHandlers = new HashMap<Integer, IAirHandler>();
+
+	public PneumaticCraftSharedStorage(SharedStorageHandler storageHandler,	int coord, int side) {
+		super(storageHandler, coord, side);
+
+		this.side = side;
+		this.coord = coord;
+
+		interfaceAirHandler = AirHandlerSupplier.getAirHandler(30, 50, 1000);
+	}
+
+	@Override
+	public String type() {
+		return "PneumaticCraft";
+	}
+
+	@Override
+	public NBTTagCompound saveToTag() {
+		NBTTagCompound tag = new NBTTagCompound();
+		interfaceAirHandler.writeToNBTI(tag);
+		return tag;
+	}
+
+	@Override
+	public void loadFromTag(NBTTagCompound tag) {
+		if (tag.hasNoTags()) {
+			return;
+		}
+		interfaceAirHandler.readFromNBTI(tag);
+	}
+
+	public void validateInterfaceAirHandler(TileEntity tile) {
+		if (tile == null || tile.getWorldObj() == null) {
+			return;
+		}
+		interfaceAirHandler.validateI(tile);
+		interfaceValid = true;
+		connectAll();
+		setDirty();
+	}
+
+	public void invalidateInterfaceAirHandler() {
+		disconnectAll();
+		interfaceValid = false;
+	}
+
+	public IAirHandler getInterfaceAirHandler() {
+		if (!isInterfaceValid()) {
+			return null;
+		}
+		setDirty();
+		return interfaceAirHandler;
+	}
+
+	public boolean isInterfaceValid() {
+		return interfaceValid;
+	}
+
+	public Object createDummyAirHandler(TileEntity tile) {
+		if (tile == null || tile.getWorldObj() == null) {
+			return null;
+		}
+		IAirHandler dummyAirHandler = AirHandlerSupplier.getAirHandler(30, 50, 1);
+		dummyAirHandler.validateI(tile);
+		return dummyAirHandler;
+	}
+
+	public void connectAirHandler(int entangledInstance, TileEntity tile) {
+		if (tile == null || tile.getWorldObj() == null) {
+			return;
+		}
+		IAirHandler existHandler = connectedHandlers.get(entangledInstance);
+		IAirHandler newHandler = getHandlerFromTile(tile);
+		if (existHandler != newHandler) {
+			removeAirHandler(entangledInstance);
+			if (newHandler != null) {
+				connectedHandlers.put(entangledInstance, newHandler);
+				if (isInterfaceValid()) {
+					interfaceAirHandler.createConnection(newHandler);
+				}
+			}
+		}
+	}
+
+	public void removeAirHandler(int entangledInstance) {
+		if (connectedHandlers.containsKey(entangledInstance)) {
+			if (isInterfaceValid()) {
+				interfaceAirHandler.removeConnection(connectedHandlers.get(entangledInstance));
+			}
+			connectedHandlers.remove(entangledInstance);
+		}
+	}
+
+	private IAirHandler getHandlerFromTile(TileEntity tile) {
+		IAirHandler handler = null;
+        if(tile instanceof IPneumaticMachine && ((IPneumaticMachine)tile).isConnectedTo(ForgeDirection.getOrientation(side).getOpposite())) {
+        	handler = ((IPneumaticMachine)tile).getAirHandler();
+        } else if(tile instanceof ISidedPneumaticMachine) {
+            handler = ((ISidedPneumaticMachine)tile).getAirHandler(ForgeDirection.getOrientation(side).getOpposite());
+        }
+
+		return handler;
+	}
+
+	private void connectAll() {
+		if (isInterfaceValid()) {
+			for (IAirHandler handler : connectedHandlers.values()) {
+				interfaceAirHandler.createConnection(handler);
+			}
+		}
+	}
+
+	private void disconnectAll() {
+		if (isInterfaceValid()) {
+			for (IAirHandler handler : connectedHandlers.values()) {
+				interfaceAirHandler.removeConnection(handler);
+			}
+		}
+		connectedHandlers.clear();
+	}
+}

--- a/src/main/java/org/dave/CompactMachines/integration/thaumcraft/ThaumcraftSharedStorage.java
+++ b/src/main/java/org/dave/CompactMachines/integration/thaumcraft/ThaumcraftSharedStorage.java
@@ -1,0 +1,212 @@
+package org.dave.CompactMachines.integration.thaumcraft;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.dave.CompactMachines.handler.ConfigurationHandler;
+import org.dave.CompactMachines.handler.SharedStorageHandler;
+import org.dave.CompactMachines.integration.AbstractHoppingStorage;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.IEssentiaTransport;
+import cpw.mods.fml.common.Optional;
+
+@Optional.Interface(iface = "thaumcraft.api.aspects.IEssentiaTransport", modid = "Thaumcraft")
+public class ThaumcraftSharedStorage extends AbstractHoppingStorage implements IEssentiaTransport {
+	private static Map <String, Integer> aspectToID = new HashMap<String, Integer>();
+	private static Map <Integer, String> idToAspect = new HashMap<Integer, String>();
+	protected Aspect aspect;
+	protected int aspectAmount;
+
+	public ThaumcraftSharedStorage(SharedStorageHandler storageHandler, int coord, int side) {
+		super(storageHandler, coord, side);
+
+		max_cooldown = ConfigurationHandler.cooldownEssentia;
+
+		this.side = side;
+		this.coord = coord;
+		super.setHoppingMode(4);
+		if(aspectToID.isEmpty()) {
+			ArrayList<String> aspectNames = new ArrayList<String>();
+			for(Aspect aspect : Aspect.aspects.values()) {
+				aspectNames.add(aspect.getTag());
+			}
+			Collections.sort(aspectNames);
+			int id = 0;
+
+			for(String aspect : aspectNames) {
+				aspectToID.put(aspect, id);
+				idToAspect.put(id++, aspect);
+			}
+		}
+	}
+
+	@Override
+	public NBTTagCompound saveToTag() {
+		NBTTagCompound compound = new NBTTagCompound();
+		if(aspect != null) {
+			compound.setString("Aspect", aspect.getTag());
+			compound.setInteger("AspectAmount", aspectAmount);
+		}
+		return compound;
+	}
+
+	@Override
+	public void loadFromTag(NBTTagCompound tag) {
+		aspect = Aspect.getAspect(tag.getString("Aspect"));
+		aspectAmount = tag.getInteger("AspectAmount");
+	}
+
+	@Override
+	public String type() {
+		return "thaumcraft";
+	}
+
+	@Override
+	public void setHoppingMode(int mode) {}
+
+	@Override
+	public boolean isConnectable(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean canInputFrom(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean canOutputTo(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void setSuction(Aspect aspect, int amount) {}
+
+	@Override
+	public Aspect getSuctionType(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return null;
+		}
+		return aspect == null ? null : aspect;
+	}
+
+	@Override
+	public int getSuctionAmount(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
+		return ConfigurationHandler.capacityEssentia >= aspectAmount ? 48 : 0;
+	}
+
+	@Override
+	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		if(ConfigurationHandler.enableIntegrationThaumcraft) {
+			if((aspect == null || aspect == this.aspect) && amount <= aspectAmount) {
+				aspectAmount -= amount;
+				if(aspectAmount <= 0) {
+					this.aspect = null;
+					aspectAmount = 0;
+				}
+				setDirty();
+				return amount;
+			}
+		}
+		return 0;
+	}
+
+	@Override
+	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		if(ConfigurationHandler.enableIntegrationThaumcraft) {
+			if((this.aspect == null || aspect == this.aspect)) {
+				this.aspect = aspect;
+				int amountToAdd = Math.min(amount, ConfigurationHandler.capacityEssentia - aspectAmount);
+				aspectAmount += amountToAdd;
+				setDirty();
+				return amountToAdd;
+			}
+		}
+		return 0;
+	}
+
+	@Override
+	public Aspect getEssentiaType(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return null;
+		}
+		return aspect;
+	}
+
+	@Override
+	public int getEssentiaAmount(ForgeDirection face) {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
+		return aspectAmount;
+	}
+
+	@Override
+	public int getMinimumSuction() {
+		if(!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return Integer.MAX_VALUE;
+		}
+		return 48;
+	}
+
+	@Override
+	public boolean renderExtendedTube() {
+		return false;
+	}
+
+	@Override
+	public void hopToTileEntity(TileEntity target, boolean useOppositeSide) {
+		if (aspectAmount >= ConfigurationHandler.capacityEssentia || !(target instanceof IEssentiaTransport)) {
+			return;
+		}
+
+		IEssentiaTransport et = (IEssentiaTransport) target;
+
+		ForgeDirection hoppingSide = ForgeDirection.getOrientation(side);
+		if (useOppositeSide) {
+			hoppingSide = hoppingSide.getOpposite();
+		}
+
+		if (et.isConnectable(hoppingSide.getOpposite()) && et.canOutputTo(hoppingSide.getOpposite())) {
+			Aspect ta = null;
+
+			if ((aspect != null) && (aspectAmount > 0)) {
+				ta = aspect;
+			} else if ((et.getEssentiaAmount(hoppingSide.getOpposite()) > 0) && 
+					(et.getSuctionAmount(hoppingSide.getOpposite()) < getSuctionAmount(hoppingSide)) && (getSuctionAmount(hoppingSide) >= et.getMinimumSuction())) {
+				ta = et.getEssentiaType(hoppingSide.getOpposite());
+			}
+			if ((ta != null) && (et.getSuctionAmount(hoppingSide.getOpposite()) < getSuctionAmount(hoppingSide))) {
+				
+				addEssentia(ta, et.takeEssentia(ta, 1, hoppingSide.getOpposite()), hoppingSide);
+			}
+		}
+	}
+
+	public static int getIDForAspect(Aspect aspect) {
+		return aspectToID.get(aspect.getTag());
+	}
+
+	public static Aspect getAspectForID(int ID) {
+		return Aspect.getAspect(idToAspect.get(ID));
+	}
+}

--- a/src/main/java/org/dave/CompactMachines/integration/thaumcraft/ThaumcraftSharedStorage.java
+++ b/src/main/java/org/dave/CompactMachines/integration/thaumcraft/ThaumcraftSharedStorage.java
@@ -175,6 +175,10 @@ public class ThaumcraftSharedStorage extends AbstractHoppingStorage implements I
 
 	@Override
 	public void hopToTileEntity(TileEntity target, boolean useOppositeSide) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return;
+		}
+		
 		if (aspectAmount >= ConfigurationHandler.capacityEssentia || !(target instanceof IEssentiaTransport)) {
 			return;
 		}
@@ -196,7 +200,6 @@ public class ThaumcraftSharedStorage extends AbstractHoppingStorage implements I
 				ta = et.getEssentiaType(hoppingSide.getOpposite());
 			}
 			if ((ta != null) && (et.getSuctionAmount(hoppingSide.getOpposite()) < getSuctionAmount(hoppingSide))) {
-				
 				addEssentia(ta, et.takeEssentia(ta, 1, hoppingSide.getOpposite()), hoppingSide);
 			}
 		}

--- a/src/main/java/org/dave/CompactMachines/inventory/ContainerInterface.java
+++ b/src/main/java/org/dave/CompactMachines/inventory/ContainerInterface.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.reference.Reference;
 import org.dave.CompactMachines.tileentity.TileEntityInterface;
 
@@ -59,6 +60,10 @@ public class ContainerInterface extends ContainerCM {
 			tileEntityInterface._gasid = value;
 		} else if (var == 37) {
 			tileEntityInterface._mana = value;
+		} else if (var == 38) {
+			tileEntityInterface._aspectamount = value;
+		} else if (var == 39) {
+			tileEntityInterface._aspectid = value;
 		}
 	}
 
@@ -106,6 +111,16 @@ public class ContainerInterface extends ContainerCM {
 
 			if(Reference.BOTANIA_AVAILABLE) {
 				((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 37, tileEntityInterface.getCurrentMana());
+			}
+
+			if(Reference.THAUMCRAFT_AVAILABLE) {
+				if (tileEntityInterface.getEssentiaAmount(ForgeDirection.UNKNOWN) > 0) {
+					((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 38, tileEntityInterface.getEssentiaAmount(ForgeDirection.UNKNOWN));
+					((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 39, ThaumcraftSharedStorage.getIDForAspect(tileEntityInterface.getEssentiaType(ForgeDirection.UNKNOWN)));
+				} else {
+					((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 38, 0);
+					((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 39, 0);
+				}
 			}
 		}
 	}

--- a/src/main/java/org/dave/CompactMachines/inventory/ContainerMachine.java
+++ b/src/main/java/org/dave/CompactMachines/inventory/ContainerMachine.java
@@ -9,9 +9,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.reference.Reference;
 import org.dave.CompactMachines.tileentity.TileEntityMachine;
 
+import thaumcraft.api.aspects.Aspect;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -112,6 +114,30 @@ public class ContainerMachine extends ContainerCM {
 			tileEntityMachine._gasid[5] = value;
 		} else if (var == 80) {
 			tileEntityMachine._mana = value;
+		} else if (var == 81) {
+			tileEntityMachine._aspectamount[0] = value;
+		} else if (var == 82) {
+			tileEntityMachine._aspectamount[1] = value;
+		} else if (var == 83) {
+			tileEntityMachine._aspectamount[2] = value;
+		} else if (var == 84) {
+			tileEntityMachine._aspectamount[3] = value;
+		} else if (var == 85) {
+			tileEntityMachine._aspectamount[4] = value;
+		} else if (var == 86) {
+			tileEntityMachine._aspectamount[5] = value;
+		} else if (var == 87) {
+			tileEntityMachine._aspectid[0] = value;
+		} else if (var == 88) {
+			tileEntityMachine._aspectid[1] = value;
+		} else if (var == 89) {
+			tileEntityMachine._aspectid[2] = value;
+		} else if (var == 90) {
+			tileEntityMachine._aspectid[3] = value;
+		} else if (var == 91) {
+			tileEntityMachine._aspectid[4] = value;
+		} else if (var == 92) {
+			tileEntityMachine._aspectid[5] = value;
 		}
 	}
 
@@ -125,7 +151,6 @@ public class ContainerMachine extends ContainerCM {
 				((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 80, tileEntityMachine.getCurrentMana());
 			}
 		}
-
 
 		for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 			FluidTankInfo[] tanks = tileEntityMachine.getTankInfo(dir);
@@ -156,6 +181,23 @@ public class ContainerMachine extends ContainerCM {
 						} else {
 							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 66 + dir.ordinal(), 0);
 							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 72 + dir.ordinal(), 0);
+						}
+					}
+				}
+			}
+
+			if(Reference.THAUMCRAFT_AVAILABLE) {
+				Aspect aspect = tileEntityMachine.getEssentiaType(dir);
+				int aspectAmount = tileEntityMachine.getEssentiaAmount(dir);
+
+				if (aspect != null) {
+					for (int i = 0; i < crafters.size(); i++) {
+						if (aspectAmount > 0) {
+							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 81 + dir.ordinal(), aspectAmount);
+							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 87 + dir.ordinal(), ThaumcraftSharedStorage.getIDForAspect(aspect));
+						} else {
+							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 81 + dir.ordinal(), 0);
+							((ICrafting) crafters.get(i)).sendProgressBarUpdate(this, 87 + dir.ordinal(), 0);
 						}
 					}
 				}

--- a/src/main/java/org/dave/CompactMachines/reference/Reference.java
+++ b/src/main/java/org/dave/CompactMachines/reference/Reference.java
@@ -19,6 +19,7 @@ public class Reference {
 	public static boolean		MEK_AVAILABLE		= false;
 	public static boolean		BOTANIA_AVAILABLE	= false;
 	public static boolean		THAUMCRAFT_AVAILABLE= false;
+	public static boolean		PNEUMATICCRAFT_AVAILABLE= false;
 
 	public static Item			upgradeItem			= null;
 

--- a/src/main/java/org/dave/CompactMachines/reference/Reference.java
+++ b/src/main/java/org/dave/CompactMachines/reference/Reference.java
@@ -18,6 +18,7 @@ public class Reference {
 	public static boolean		OC_AVAILABLE		= false;
 	public static boolean		MEK_AVAILABLE		= false;
 	public static boolean		BOTANIA_AVAILABLE	= false;
+	public static boolean		THAUMCRAFT_AVAILABLE= false;
 
 	public static Item			upgradeItem			= null;
 

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityCM.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityCM.java
@@ -26,112 +26,99 @@ public class TileEntityCM extends TileEntity {
 	public Packet getDescriptionPacket() {
 		NBTTagCompound tag = new NBTTagCompound();
 		writeToNBT(tag);
+		writeSyncNBT(tag);
 		return new S35PacketUpdateTileEntity(xCoord, yCoord, zCoord, 0, tag);
 	}
 
 	@Override
 	public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
-		readFromNBT(pkt.func_148857_g());
+		NBTTagCompound tag = pkt.func_148857_g();
+		readFromNBT(tag);
+		readSyncNBT(tag);
 	}
 
-	public ForgeDirection getOrientation()
-	{
+	public ForgeDirection getOrientation() {
 		return orientation;
 	}
 
-	public void setOrientation(ForgeDirection orientation)
-	{
+	public void setOrientation(ForgeDirection orientation) {
 		this.orientation = orientation;
 	}
 
-	public void setOrientation(int orientation)
-	{
+	public void setOrientation(int orientation) {
 		this.orientation = ForgeDirection.getOrientation(orientation);
 	}
 
-	public short getState()
-	{
+	public short getState() {
 		return state;
 	}
 
-	public void setState(byte state)
-	{
+	public void setState(byte state) {
 		this.state = state;
 	}
 
-	public String getCustomName()
-	{
+	public String getCustomName() {
 		return customName;
 	}
 
-	public void setCustomName(String customName)
-	{
+	public void setCustomName(String customName) {
 		this.customName = customName;
 	}
 
-	public String getOwner()
-	{
+	public String getOwner() {
 		return owner;
 	}
 
-	public void setOwner(String owner)
-	{
+	public void setOwner(String owner) {
 		this.owner = owner;
 	}
 
 	@Override
-	public void readFromNBT(NBTTagCompound nbtTagCompound)
-	{
+	public void readFromNBT(NBTTagCompound nbtTagCompound) {
 		super.readFromNBT(nbtTagCompound);
 
-		if (nbtTagCompound.hasKey(Names.NBT.DIRECTION))
-		{
+		if (nbtTagCompound.hasKey(Names.NBT.DIRECTION)) {
 			this.orientation = ForgeDirection.getOrientation(nbtTagCompound.getByte(Names.NBT.DIRECTION));
 		}
 
-		if (nbtTagCompound.hasKey(Names.NBT.STATE))
-		{
+		if (nbtTagCompound.hasKey(Names.NBT.STATE)) {
 			this.state = nbtTagCompound.getByte(Names.NBT.STATE);
 		}
 
-		if (nbtTagCompound.hasKey(Names.NBT.CUSTOM_NAME))
-		{
+		if (nbtTagCompound.hasKey(Names.NBT.CUSTOM_NAME)) {
 			this.customName = nbtTagCompound.getString(Names.NBT.CUSTOM_NAME);
 		}
 
-		if (nbtTagCompound.hasKey(Names.NBT.OWNER))
-		{
+		if (nbtTagCompound.hasKey(Names.NBT.OWNER)) {
 			this.owner = nbtTagCompound.getString(Names.NBT.OWNER);
 		}
 	}
 
+	protected void readSyncNBT(NBTTagCompound tag) {}
+
 	@Override
-	public void writeToNBT(NBTTagCompound nbtTagCompound)
-	{
+	public void writeToNBT(NBTTagCompound nbtTagCompound) {
 		super.writeToNBT(nbtTagCompound);
 
 		nbtTagCompound.setByte(Names.NBT.DIRECTION, (byte) orientation.ordinal());
 		nbtTagCompound.setByte(Names.NBT.STATE, state);
 
-		if (this.hasCustomName())
-		{
+		if (this.hasCustomName()) {
 			nbtTagCompound.setString(Names.NBT.CUSTOM_NAME, customName);
 		}
 
-		if (this.hasOwner())
-		{
+		if (this.hasOwner()) {
 			nbtTagCompound.setString(Names.NBT.OWNER, owner);
 		}
 	}
 
-	public boolean hasCustomName()
-	{
+	protected void writeSyncNBT(NBTTagCompound tag) {}
+
+	public boolean hasCustomName() {
 		return customName != null && customName.length() > 0;
 	}
 
-	public boolean hasOwner()
-	{
+	public boolean hasOwner() {
 		return owner != null && owner.length() > 0;
 	}
-
 }

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityInterface.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityInterface.java
@@ -295,7 +295,7 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	}
 
 	private void hopStorage(AbstractHoppingStorage storage, TileEntity tileEntityInside) {
-		if (storage != null && storage.getHoppingMode() == 4 || (storage.getHoppingMode() == 1 || storage.getHoppingMode() == 3 && storage.isAutoHoppingToInside() == true)) {
+		if (storage != null && (storage.getHoppingMode() == 4 || (storage.getHoppingMode() == 1 || storage.getHoppingMode() == 3 && storage.isAutoHoppingToInside() == true))) {
 			storage.hopToTileEntity(tileEntityInside, false);
 		}
 	}
@@ -613,18 +613,27 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean isConnectable(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
 		return getStorageThaumcraft().isConnectable(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean canInputFrom(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
 		return getStorageThaumcraft().canInputFrom(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean canOutputTo(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
 		return getStorageThaumcraft().canOutputTo(face);
 	}
 
@@ -635,54 +644,81 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public Aspect getSuctionType(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return null;
+		}
 		return getStorageThaumcraft().getSuctionType(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getSuctionAmount(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
 		return getStorageThaumcraft().getSuctionAmount(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
 		return getStorageThaumcraft().takeEssentia(aspect, amount, face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
 		return getStorageThaumcraft().addEssentia(aspect, amount, face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public Aspect getEssentiaType(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return null;
+		}
 		return getStorageThaumcraft().getEssentiaType(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getEssentiaAmount(ForgeDirection face) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return 0;
+		}
 		return getStorageThaumcraft().getEssentiaAmount(face);
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getMinimumSuction() {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return Integer.MAX_VALUE;
+		}
 		return getStorageThaumcraft().getMinimumSuction();
 	}
 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean renderExtendedTube() {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft) {
+			return false;
+		}
 		return getStorageThaumcraft().renderExtendedTube();
 	}
 
 	@Override
 	@Optional.Method(modid = "PneumaticCraft")
 	public IAirHandler getAirHandler(ForgeDirection side) {
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return null;
+		}
 		if (getStoragePneumaticCraft().isInterfaceValid()) {
 			return getStoragePneumaticCraft().getInterfaceAirHandler();
 		}
@@ -692,12 +728,18 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	@Override
 	@Optional.Method(modid = "PneumaticCraft")
 	public void printManometerMessage(EntityPlayer player, List<String> curInfo) {
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return;
+		}
 		if(Reference.PNEUMATICCRAFT_AVAILABLE && getStoragePneumaticCraft().isInterfaceValid()) {
 			getStoragePneumaticCraft().getInterfaceAirHandler().printManometerMessage(player, curInfo);
 		}
 	}
 
 	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return;
+		}
 		if(Reference.PNEUMATICCRAFT_AVAILABLE && getStoragePneumaticCraft().isInterfaceValid()) {
 			getStoragePneumaticCraft().getInterfaceAirHandler().onNeighborChange();
 		}

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityInterface.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityInterface.java
@@ -33,9 +33,12 @@ import org.dave.CompactMachines.integration.gas.GasSharedStorage;
 import org.dave.CompactMachines.integration.item.ItemSharedStorage;
 import org.dave.CompactMachines.integration.opencomputers.OpenComputersSharedStorage;
 import org.dave.CompactMachines.integration.redstoneflux.FluxSharedStorage;
+import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.reference.Names;
 import org.dave.CompactMachines.reference.Reference;
 
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.IEssentiaTransport;
 import vazkii.botania.api.mana.IManaPool;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
@@ -49,9 +52,10 @@ import cpw.mods.fml.common.Optional;
 		@Optional.Interface(iface = "li.cil.oc.api.network.Environment", modid = "OpenComputers"),
 		@Optional.Interface(iface = "mekanism.api.gas.IGasHandler", modid = "Mekanism"),
 		@Optional.Interface(iface = "mekanism.api.gas.ITubeConnection", modid = "Mekanism"),
-		@Optional.Interface(iface = "vazkii.botania.api.mana.IManaPool", modid = "Botania")
+		@Optional.Interface(iface = "vazkii.botania.api.mana.IManaPool", modid = "Botania"),
+		@Optional.Interface(iface = "thaumcraft.api.aspects.IEssentiaTransport", modid = "Thaumcraft")
 })
-public class TileEntityInterface extends TileEntityCM implements IInventory, IFluidHandler, IGasHandler, ITubeConnection, IEnergyHandler, IGridHost, IBundledTile, Environment, IManaPool {
+public class TileEntityInterface extends TileEntityCM implements IInventory, IFluidHandler, IGasHandler, ITubeConnection, IEnergyHandler, IGridHost, IBundledTile, Environment, IManaPool, IEssentiaTransport {
 
 	public CMGridBlock	gridBlock;
 
@@ -65,6 +69,8 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	public int			_energy;
 	public int			_mana;
 	public int			_hoppingmode;
+	public int			_aspectid;
+	public int			_aspectamount;
 
 	public TileEntityInterface() {
 		super();
@@ -74,6 +80,8 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 		_gasamount = 0;
 		_energy = 0;
 		_mana = 0;
+		_aspectid = -1;
+		_aspectamount = 0;
 	}
 
 	public ItemSharedStorage getStorageItem() {
@@ -107,6 +115,10 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 
 	public BotaniaSharedStorage getStorageBotania() {
 		return (BotaniaSharedStorage) SharedStorageHandler.instance(worldObj.isRemote).getStorage(this.coords, 0, "botania");
+	}
+
+	public ThaumcraftSharedStorage getStorageThaumcraft() {
+		return (ThaumcraftSharedStorage) SharedStorageHandler.instance(worldObj.isRemote).getStorage(this.coords, side, "thaumcraft");
 	}
 
 	@Override
@@ -227,7 +239,7 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 	}
 
 	private void hopStorage(AbstractHoppingStorage storage, TileEntity tileEntityInside) {
-		if (storage != null && (storage.getHoppingMode() == 1 || storage.getHoppingMode() == 3 && storage.isAutoHoppingToInside() == true)) {
+		if (storage != null && storage.getHoppingMode() == 4 || (storage.getHoppingMode() == 1 || storage.getHoppingMode() == 3 && storage.isAutoHoppingToInside() == true)) {
 			storage.hopToTileEntity(tileEntityInside, false);
 		}
 	}
@@ -542,4 +554,73 @@ public class TileEntityInterface extends TileEntityCM implements IInventory, IFl
 		return getStorageBotania().isOutputtingPower();
 	}
 
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public boolean isConnectable(ForgeDirection face) {
+		return getStorageThaumcraft().isConnectable(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public boolean canInputFrom(ForgeDirection face) {
+		return getStorageThaumcraft().canInputFrom(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public boolean canOutputTo(ForgeDirection face) {
+		return getStorageThaumcraft().canOutputTo(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public void setSuction(Aspect aspect, int amount) {}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public Aspect getSuctionType(ForgeDirection face) {
+		return getStorageThaumcraft().getSuctionType(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public int getSuctionAmount(ForgeDirection face) {
+		return getStorageThaumcraft().getSuctionAmount(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		return getStorageThaumcraft().takeEssentia(aspect, amount, face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
+		return getStorageThaumcraft().addEssentia(aspect, amount, face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public Aspect getEssentiaType(ForgeDirection face) {
+		return getStorageThaumcraft().getEssentiaType(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public int getEssentiaAmount(ForgeDirection face) {
+		return getStorageThaumcraft().getEssentiaAmount(face);
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public int getMinimumSuction() {
+		return getStorageThaumcraft().getMinimumSuction();
+	}
+
+	@Override
+	@Optional.Method(modid = "Thaumcraft")
+	public boolean renderExtendedTube() {
+		return getStorageThaumcraft().renderExtendedTube();
+	}
 }

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
@@ -1,25 +1,33 @@
 package org.dave.CompactMachines.tileentity;
 
 import java.util.HashMap;
+import java.util.List;
 
 import li.cil.oc.api.network.Node;
 import li.cil.oc.api.network.SidedEnvironment;
+
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.ITubeConnection;
+
 import mrtjp.projectred.api.IBundledTile;
 import mrtjp.projectred.api.ProjectRedAPI;
+
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.Vec3;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -40,6 +48,7 @@ import org.dave.CompactMachines.integration.fluid.FluidSharedStorage;
 import org.dave.CompactMachines.integration.gas.GasSharedStorage;
 import org.dave.CompactMachines.integration.item.ItemSharedStorage;
 import org.dave.CompactMachines.integration.opencomputers.OpenComputersSharedStorage;
+import org.dave.CompactMachines.integration.pneumaticcraft.PneumaticCraftSharedStorage;
 import org.dave.CompactMachines.integration.redstoneflux.FluxSharedStorage;
 import org.dave.CompactMachines.integration.thaumcraft.ThaumcraftSharedStorage;
 import org.dave.CompactMachines.machines.tools.ChunkLoadingTools;
@@ -47,14 +56,22 @@ import org.dave.CompactMachines.machines.tools.CubeTools;
 import org.dave.CompactMachines.reference.Names;
 import org.dave.CompactMachines.reference.Reference;
 
+import pneumaticCraft.api.tileentity.IAirHandler;
+import pneumaticCraft.api.tileentity.IManoMeasurable;
+import pneumaticCraft.api.tileentity.ISidedPneumaticMachine;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.IEssentiaTransport;
+
 import vazkii.botania.api.mana.IManaPool;
+
 import appeng.api.movable.IMovableTile;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
 import appeng.api.util.AECableType;
+
 import cofh.api.energy.IEnergyHandler;
+
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -67,9 +84,11 @@ import cpw.mods.fml.relauncher.SideOnly;
 		@Optional.Interface(iface = "mekanism.api.gas.IGasHandler", modid = "Mekanism"),
 		@Optional.Interface(iface = "mekanism.api.gas.ITubeConnection", modid = "Mekanism"),
 		@Optional.Interface(iface = "vazkii.botania.api.mana.IManaPool", modid = "Botania"),
-		@Optional.Interface(iface = "thaumcraft.api.aspects.IEssentiaTransport", modid = "Thaumcraft")
+		@Optional.Interface(iface = "thaumcraft.api.aspects.IEssentiaTransport", modid = "Thaumcraft"),
+		@Optional.Interface(iface = "pneumaticCraft.api.tileentity.ISidedPneumaticMachine", modid = "PneumaticCraft"),
+		@Optional.Interface(iface = "pneumaticCraft.api.tileentity.IManoMeasurable", modid = "PneumaticCraft")
 })
-public class TileEntityMachine extends TileEntityCM implements ISidedInventory, IFluidHandler, IGasHandler, ITubeConnection, IEnergyHandler, IGridHost, IMovableTile, IBundledTile, SidedEnvironment, IManaPool, IEssentiaTransport {
+public class TileEntityMachine extends TileEntityCM implements ISidedInventory, IFluidHandler, IGasHandler, ITubeConnection, IEnergyHandler, IGridHost, IMovableTile, IBundledTile, SidedEnvironment, IManaPool, IEssentiaTransport, ISidedPneumaticMachine, IManoMeasurable {
 
 	public int								coords			= -1;
 	public int[]							_fluidid;
@@ -89,7 +108,9 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 
 	public HashMap<Integer, CMGridBlock>	gridBlocks;
 	public HashMap<Integer, IGridNode>		gridNodes;
+
 	private boolean							init;
+	private Object[]						airHandlers;
 
 	public static final int					INVENTORY_SIZE	= 6;
 
@@ -109,6 +130,8 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 
 		gridBlocks = new HashMap<Integer, CMGridBlock>();
 		gridNodes = new HashMap<Integer, IGridNode>();
+
+		airHandlers = new Object[6];
 	}
 
 	@Override
@@ -153,6 +176,10 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 		return (ThaumcraftSharedStorage) SharedStorageHandler.instance(worldObj.isRemote).getStorage(this.coords, side, "thaumcraft");
 	}
 
+	public PneumaticCraftSharedStorage getStoragePneumaticCraft(int side) {
+		return (PneumaticCraftSharedStorage) SharedStorageHandler.instance(worldObj.isRemote).getStorage(this.coords, side, "PneumaticCraft");
+	}
+
 	@Override
 	public void readFromNBT(NBTTagCompound nbtTagCompound)
 	{
@@ -169,6 +196,18 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	}
 
 	@Override
+	protected void readSyncNBT(NBTTagCompound tag) {
+		if (Reference.PNEUMATICCRAFT_AVAILABLE && tag.hasKey("AirHandlers")) {
+			NBTTagList handlers = tag.getTagList("AirHandlers", Constants.NBT.TAG_LIST);
+			for (int i = 0; i < handlers.tagCount(); i++) {
+				NBTTagCompound sideTag = handlers.getCompoundTagAt(i);
+				int side = sideTag.getInteger("dir");
+				((IAirHandler)airHandlers[side]).readFromNBTI(sideTag);
+			}
+		}
+	}
+
+	@Override
 	public void writeToNBT(NBTTagCompound nbtTagCompound)
 	{
 		super.writeToNBT(nbtTagCompound);
@@ -180,6 +219,37 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 		nbtTagCompound.setInteger("coords", coords);
 		nbtTagCompound.setBoolean("upgraded", isUpgraded);
 		nbtTagCompound.setInteger("entangle-id", entangledInstance);
+	}
+
+	@Override
+	protected void writeSyncNBT(NBTTagCompound tag) {
+		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
+			NBTTagList tagList = new NBTTagList();
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				if (airHandlers[dir.ordinal()] != null) {
+					NBTTagCompound sideTag = new NBTTagCompound();
+					 ((IAirHandler)airHandlers[dir.ordinal()]).writeToNBTI(sideTag);
+					 sideTag.setInteger("dir", dir.ordinal());
+					 tagList.appendTag(sideTag);
+				}
+			}
+			if (tagList.tagCount() > 0) {
+				tag.setTag("AirHandlers", tagList);
+			}
+		}
+	}
+
+	@Override
+	public void validate() {
+		super.validate();
+		
+		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				if (getStoragePneumaticCraft(dir.ordinal()) != null) {
+					airHandlers[dir.ordinal()] = getStoragePneumaticCraft(dir.ordinal()).createDummyAirHandler(this);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -224,10 +294,20 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 				storageAE.destroyMachineNode(entangledInstance);
 				CompactMachines.instance.entangleRegistry.removeMachineTile(this);
 			}
+
+			PneumaticCraftSharedStorage storagePC = getStoragePneumaticCraft(dir.ordinal());
+			if (storagePC != null) {
+				airHandlers = new Object[6];
+				storagePC.removeAirHandler(entangledInstance);
+			}
 		}
 	}
 
 	public void initialize() {
+		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
+			onNeighborChange(worldObj, xCoord, yCoord, zCoord, xCoord, yCoord, zCoord);
+		}
+
 		if (worldObj.isRemote) {
 			return;
 		}
@@ -268,6 +348,10 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 			updateIncomingSignals();
 		}
 
+		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
+			updateDummyAirHandlers();
+		}
+
 		if (!worldObj.isRemote) {
 			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 				TileEntity outside = worldObj.getTileEntity(xCoord + dir.offsetX, yCoord + dir.offsetY, zCoord + dir.offsetZ);
@@ -281,7 +365,6 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 			}
 		}
 	}
-
 
 	public ChunkCoordinates getChunkCoordinates() {
 		int x = coords * ConfigurationHandler.cubeDistance;
@@ -303,6 +386,16 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 
 		if (hoppingStorage.getHoppingMode() == 4 || (hoppingStorage.getHoppingMode() == 2 || (hoppingStorage.getHoppingMode() == 3 && hoppingStorage.isAutoHoppingToInside() == false))) {
 			hoppingStorage.hoppingTick(outside, true);
+		}
+	}
+
+	private void updateDummyAirHandlers() {
+		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				if (airHandlers[dir.ordinal()] != null) {
+					((IAirHandler)airHandlers[dir.ordinal()]).updateEntityI();
+				}
+			}
 		}
 	}
 
@@ -910,5 +1003,55 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 			return false;
 		}
 		return getStorageThaumcraft(0).renderExtendedTube();
+	}
+
+	@Override
+	@Optional.Method(modid = "PneumaticCraft")
+	public IAirHandler getAirHandler(ForgeDirection side) {
+		return (IAirHandler)airHandlers[side.ordinal()];
+	}
+
+	@Override
+	@Optional.Method(modid = "PneumaticCraft")
+	public void printManometerMessage(EntityPlayer player, List<String> curInfo) {
+		if(Reference.PNEUMATICCRAFT_AVAILABLE) {
+			if (coords != -1) {
+				curInfo.add(EnumChatFormatting.GREEN + "Pressures:");
+				for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+					if (getStoragePneumaticCraft(dir.ordinal()) != null) {
+						curInfo.add(EnumChatFormatting.GREEN + "Current pressure (" + dir.name() + "): " + roundNumberTo(getStoragePneumaticCraft(dir.ordinal()).getInterfaceAirHandler().getPressure(ForgeDirection.UNKNOWN), 1) + " bar.");
+					}
+				}
+			}
+		}
+	}
+
+	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		if(Reference.PNEUMATICCRAFT_AVAILABLE) {
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				if (airHandlers[dir.ordinal()] != null) {
+					((IAirHandler)airHandlers[dir.ordinal()]).onNeighborChange();
+				}
+				if (getStoragePneumaticCraft(dir.ordinal()) != null) {
+					int targetX = xCoord + ForgeDirection.getOrientation(dir.ordinal()).offsetX;
+					int targetY = yCoord + ForgeDirection.getOrientation(dir.ordinal()).offsetY;
+					int targetZ = zCoord + ForgeDirection.getOrientation(dir.ordinal()).offsetZ;
+					getStoragePneumaticCraft(dir.ordinal()).connectAirHandler(entangledInstance, worldObj.getTileEntity(targetX, targetY, targetZ));
+				}
+			}
+		}
+	}
+
+	private static String roundNumberTo(double value, int decimals){
+		double ret = roundNumberToDouble(value, decimals);
+		if(decimals == 0) {
+			return "" + (int)ret;
+		} else {
+			return "" + ret;
+		}
+	}
+
+	private static double roundNumberToDouble(double value, int decimals){
+		return Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals);
 	}
 }

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
@@ -242,7 +242,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	public void validate() {
 		super.validate();
-		
+
 		if (Reference.PNEUMATICCRAFT_AVAILABLE) {
 			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 				if (getStoragePneumaticCraft(dir.ordinal()) != null) {
@@ -905,7 +905,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean isConnectable(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return false;
 		}
 		return getStorageThaumcraft(face.ordinal()).isConnectable(face);
@@ -914,7 +914,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean canInputFrom(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return false;
 		}
 		return getStorageThaumcraft(face.ordinal()).canInputFrom(face);
@@ -923,7 +923,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean canOutputTo(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return false;
 		}
 		return getStorageThaumcraft(face.ordinal()).canOutputTo(face);
@@ -936,7 +936,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public Aspect getSuctionType(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return null;
 		}
 		return getStorageThaumcraft(face.ordinal()).getSuctionType(face);
@@ -945,7 +945,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getSuctionAmount(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return 0;
 		}
 		return getStorageThaumcraft(face.ordinal()).getSuctionAmount(face);
@@ -954,7 +954,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return 0;
 		}
 		return getStorageThaumcraft(face.ordinal()).takeEssentia(aspect, amount, face);
@@ -963,7 +963,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return 0;
 		}
 		return getStorageThaumcraft(face.ordinal()).addEssentia(aspect, amount, face);
@@ -972,7 +972,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public Aspect getEssentiaType(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return null;
 		}
 		return getStorageThaumcraft(face.ordinal()).getEssentiaType(face);
@@ -981,7 +981,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getEssentiaAmount(ForgeDirection face) {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return 0;
 		}
 		return getStorageThaumcraft(face.ordinal()).getEssentiaAmount(face);
@@ -990,7 +990,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public int getMinimumSuction() {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return Integer.MAX_VALUE;
 		}
 		return getStorageThaumcraft(0).getMinimumSuction();
@@ -999,7 +999,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "Thaumcraft")
 	public boolean renderExtendedTube() {
-		if (coords == -1) {
+		if (!ConfigurationHandler.enableIntegrationThaumcraft || coords == -1) {
 			return false;
 		}
 		return getStorageThaumcraft(0).renderExtendedTube();
@@ -1008,25 +1008,32 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	@Override
 	@Optional.Method(modid = "PneumaticCraft")
 	public IAirHandler getAirHandler(ForgeDirection side) {
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return null;
+		}
 		return (IAirHandler)airHandlers[side.ordinal()];
 	}
 
 	@Override
 	@Optional.Method(modid = "PneumaticCraft")
 	public void printManometerMessage(EntityPlayer player, List<String> curInfo) {
-		if(Reference.PNEUMATICCRAFT_AVAILABLE) {
-			if (coords != -1) {
-				curInfo.add(EnumChatFormatting.GREEN + "Pressures:");
-				for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
-					if (getStoragePneumaticCraft(dir.ordinal()) != null) {
-						curInfo.add(EnumChatFormatting.GREEN + "Current pressure (" + dir.name() + "): " + roundNumberTo(getStoragePneumaticCraft(dir.ordinal()).getInterfaceAirHandler().getPressure(ForgeDirection.UNKNOWN), 1) + " bar.");
-					}
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return;
+		}
+		if(Reference.PNEUMATICCRAFT_AVAILABLE && coords != -1) {
+			curInfo.add(EnumChatFormatting.GREEN + "Pressures:");
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				if (getStoragePneumaticCraft(dir.ordinal()) != null) {
+					curInfo.add(EnumChatFormatting.GREEN + "Current pressure (" + dir.name() + "): " + roundNumberTo(getStoragePneumaticCraft(dir.ordinal()).getInterfaceAirHandler().getPressure(ForgeDirection.UNKNOWN), 1) + " bar.");
 				}
 			}
 		}
 	}
 
 	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		if (!ConfigurationHandler.enableIntegrationPneumaticCraft) {
+			return;
+		}
 		if(Reference.PNEUMATICCRAFT_AVAILABLE) {
 			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 				if (airHandlers[dir.ordinal()] != null) {

--- a/src/main/resources/assets/compactmachines/lang/en_US.lang
+++ b/src/main/resources/assets/compactmachines/lang/en_US.lang
@@ -36,6 +36,7 @@ tooltip.cm:machine.size.four=Giant
 tooltip.cm:machine.size.five=Maximum Size
 tooltip.cm:machine.coords=Machine Number
 tooltip.cm:machine.mana=Mana
+tooltip.cm:machine.unknownaspect=Unknown Aspect
 
 # Dimension Travelling
 loading.cm:enter=Shrinking to machine size. Ffffflllp.


### PR DESCRIPTION
Adds Thaumcraft essentia and Pneumaticraft pressure support to Compact Machines.

Thaumcraft:
Thaumcraft essentia is stored in a buffer similar to fluids, gases, and energy. To display it, I split the Energy bar in the same way the fluid bar is shared with gasses. Essentia suction is "48", meaning it will draw essentia from unlabeled jars, but not labeled jars.

I used the "hopping" functionality to do the "per tick" stuff that needed to be done for essentia handling. Since the tick was needed on both the inside and outside simultaneously, I added a new hopping mode that does this, mode 4. This mode is not selectable from the GUI.

PneumaticCraft:
Pressure is just passed through using pre-existing methods in the PneumaticCraft API.

Known Issues:
When a pressure tube is connected to the outside of a Compact Machine, and not connected to anything else, it does not leak air like it is supposed to. This is due to an issue in PneumaticCraft, that has been reported to the author: https://github.com/MineMaarten/PneumaticCraft/issues/705

Fixes #43