### PR TITLE
Allow entering machines without Personal Shrinking Device

### DIFF
--- a/src/main/java/org/dave/CompactMachines/block/BlockInnerWall.java
+++ b/src/main/java/org/dave/CompactMachines/block/BlockInnerWall.java
@@ -1,11 +1,16 @@
 package org.dave.CompactMachines.block;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import org.dave.CompactMachines.CompactMachines;
+import org.dave.CompactMachines.handler.ConfigurationHandler;
 import org.dave.CompactMachines.machines.tools.CubeTools;
+import org.dave.CompactMachines.machines.tools.TeleportTools;
 import org.dave.CompactMachines.reference.Names;
 
 public class BlockInnerWall extends BlockProtected {
@@ -32,5 +37,20 @@ public class BlockInnerWall extends BlockProtected {
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack) {
 		world.setBlockToAir(x, y, z);
 		return;
+	}
+
+	@Override
+	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int faceHit, float par7, float par8, float par9)
+	{
+		if (!world.isRemote && player instanceof EntityPlayerMP) {
+			if (player.getCurrentEquippedItem() == null && player.isSneaking()) {
+				if (world.provider.dimensionId == ConfigurationHandler.dimensionId) {
+					EntityPlayerMP serverPlayer = (EntityPlayerMP) player;
+					TeleportTools.teleportPlayerBackIPSD(serverPlayer);
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/org/dave/CompactMachines/client/render/RenderPersonalShrinkingDevice.java
+++ b/src/main/java/org/dave/CompactMachines/client/render/RenderPersonalShrinkingDevice.java
@@ -67,6 +67,10 @@ public class RenderPersonalShrinkingDevice implements IItemRenderer {
 
 			GL11.glTranslatef(0F, 9F, 0F);
 			font.drawString("Upgraded: " + (teMachine.isUpgraded ? "yes" : "no"), 0, 0, ConfigurationHandler.psdDisplayColor);
+			if (teMachine.hasIntegratedPSD) {
+				GL11.glTranslatef(0F, 9F, 0F);
+				font.drawString("Integrated PSD", 0, 0, ConfigurationHandler.psdDisplayColor);
+			}
 		}
 
 		GL11.glPopMatrix();

--- a/src/main/java/org/dave/CompactMachines/handler/CMEventHandler.java
+++ b/src/main/java/org/dave/CompactMachines/handler/CMEventHandler.java
@@ -98,11 +98,15 @@ public class CMEventHandler {
 		}
 
 		NBTTagCompound playerNBT = event.player.getEntityData();
-		if(!playerNBT.getBoolean("isUsingPSD")) {
+		if (playerNBT.getBoolean("hasIntegratedPSD")) {
+			event.player.setSneaking(false);
+		}
+		if(!playerNBT.getBoolean("isUsingPSD") && !playerNBT.getBoolean("hasIntegratedPSD")) {
 			event.player.addPotionEffect(new PotionEffect(Potion.wither.id, 300, 2, false));	// Wither
 			event.player.addPotionEffect(new PotionEffect(Potion.confusion.id, 300, 5, false)); // Nausea
 		} else {
 			playerNBT.removeTag("isUsingPSD");
+			playerNBT.removeTag("hasIntegratedPSD");
 		}
 	}
 

--- a/src/main/java/org/dave/CompactMachines/item/ItemPersonalShrinkingDevice.java
+++ b/src/main/java/org/dave/CompactMachines/item/ItemPersonalShrinkingDevice.java
@@ -1,5 +1,6 @@
 package org.dave.CompactMachines.item;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -7,9 +8,11 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.World;
 
 import org.dave.CompactMachines.CompactMachines;
+import org.dave.CompactMachines.block.BlockMachine;
 import org.dave.CompactMachines.handler.ConfigurationHandler;
 import org.dave.CompactMachines.machines.tools.TeleportTools;
 import org.dave.CompactMachines.reference.Names;
+import org.dave.CompactMachines.tileentity.TileEntityMachine;
 
 public class ItemPersonalShrinkingDevice extends ItemCM
 {
@@ -36,5 +39,29 @@ public class ItemPersonalShrinkingDevice extends ItemCM
 			}
 		}
 		return itemStack;
+	}
+
+	@Override
+	public boolean onItemUseFirst(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ)
+	{
+		if (!player.isSneaking() || world.isRemote) {
+			return false;
+		}
+
+		Block block = world.getBlock(x, y, z);
+		if (!(block instanceof BlockMachine)) {
+			return false;
+		}
+
+		TileEntityMachine tileEntityMachine = (TileEntityMachine) world.getTileEntity(x, y, z);
+		if (tileEntityMachine.hasIntegratedPSD) {
+			return false;
+		}
+
+		tileEntityMachine.hasIntegratedPSD = true;
+		tileEntityMachine.markDirty();
+		world.markBlockForUpdate(x, y, z);
+		itemStack.stackSize--;
+		return true;
 	}
 }

--- a/src/main/java/org/dave/CompactMachines/machines/tools/TeleportTools.java
+++ b/src/main/java/org/dave/CompactMachines/machines/tools/TeleportTools.java
@@ -106,6 +106,20 @@ public class TeleportTools {
 
 	public static void teleportPlayerToMachineWorld(EntityPlayerMP player, TileEntityMachine machine) {
 		int coords = CompactMachines.instance.machineHandler.createOrGetChunk(machine);
+
+		NBTTagCompound playerNBT = player.getEntityData();
+		// Grab the CompactMachines entry from the player NBT data
+		NBTTagCompound cmNBT;
+		if (playerNBT.hasKey(Reference.MOD_ID)) {
+			cmNBT = playerNBT.getCompoundTag(Reference.MOD_ID);
+		} else {
+			cmNBT = new NBTTagCompound();
+			playerNBT.setTag(Reference.MOD_ID, cmNBT);
+		}
+
+		cmNBT.setBoolean(
+			"fromIPSD", (machine != null && machine.hasIntegratedPSD)
+		);
 		teleportPlayerToCoords(player, coords, false);
 	}
 
@@ -175,6 +189,25 @@ public class TeleportTools {
 		} else {
 			// No coord history on the player yet - teleport him out of there.
 			TeleportTools.teleportPlayerOutOfMachineDimension(player);
+		}
+	}
+
+	public static void teleportPlayerBackIPSD(EntityPlayerMP player) {
+		NBTTagCompound playerNBT = player.getEntityData();
+		// Grab the CompactMachines entry from the player NBT data
+		NBTTagCompound cmNBT;
+		if (playerNBT.hasKey(Reference.MOD_ID)) {
+			cmNBT = playerNBT.getCompoundTag(Reference.MOD_ID);
+		} else {
+			cmNBT = new NBTTagCompound();
+			playerNBT.setTag(Reference.MOD_ID, cmNBT);
+		}
+
+		boolean fromIPSD = (cmNBT.hasKey("fromIPSD") && cmNBT.getBoolean("fromIPSD"));
+		cmNBT.setBoolean("fromIPSD", false);
+		if (fromIPSD) {
+            player.setSneaking(false);
+			TeleportTools.teleportPlayerBack(player);
 		}
 	}
 

--- a/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
+++ b/src/main/java/org/dave/CompactMachines/tileentity/TileEntityMachine.java
@@ -105,6 +105,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 	public int								entangledInstance;
 
 	public boolean							isUpgraded		= false;
+	public boolean							hasIntegratedPSD	= false;
 
 	public HashMap<Integer, CMGridBlock>	gridBlocks;
 	public HashMap<Integer, IGridNode>		gridNodes;
@@ -188,6 +189,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 		coords = nbtTagCompound.getInteger("coords");
 		meta = nbtTagCompound.getInteger("meta");
 		isUpgraded = nbtTagCompound.getBoolean("upgraded");
+		hasIntegratedPSD = nbtTagCompound.getBoolean("integratedpsd");
 		entangledInstance = nbtTagCompound.getInteger("entangle-id");
 
 		if (isUpgraded && worldObj != null && worldObj.isRemote) {
@@ -218,6 +220,7 @@ public class TileEntityMachine extends TileEntityCM implements ISidedInventory, 
 
 		nbtTagCompound.setInteger("coords", coords);
 		nbtTagCompound.setBoolean("upgraded", isUpgraded);
+		nbtTagCompound.setBoolean("integratedpsd", hasIntegratedPSD);
 		nbtTagCompound.setInteger("entangle-id", entangledInstance);
 	}
 


### PR DESCRIPTION
This pull request more or less adds what was asked in #129.
It adds the ability to upgrade CMs with a PSD by shift-right clicking on them.
Once upgraded, a CM can be entered by shift-right clicking on it with an empty hand. Similarly, inside of a CM, you can exit it by shift-right clicking on a wall.
